### PR TITLE
Refactor canvas module for better modularity (Phase 1.3: Graph Composition)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive README.md with installation guide, usage examples, project status, and citation format
 - `PortManager` class for managing input/output/cout ports ([#33](https://github.com/UTokyo-FT-MBQC/ls-pattern-compile/issues/33) Phase 1.1)
 - `CoordinateMapper` class for managing node-coordinate bidirectional mappings ([#33](https://github.com/UTokyo-FT-MBQC/ls-pattern-compile/issues/33) Phase 1.2)
+- `GraphComposer` class for handling graph composition logic ([#33](https://github.com/UTokyo-FT-MBQC/ls-pattern-compile/issues/33) Phase 1.3)
 - Unit tests for port management functionality (`tests/canvas/test_ports.py`)
 - Unit tests for coordinate mapping functionality (`tests/canvas/test_coordinates.py`)
+- Unit tests for graph composition functionality (`tests/canvas/test_composition.py`)
 
 ### Changed
 - Unified into absolute coordinate ([#24](https://github.com/UTokyo-FT-MBQC/ls-pattern-compile/pull/24))
@@ -24,8 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Moved `MixedCodeDistanceError` to `lspattern/canvas/exceptions.py`
   - Extracted port management logic into `lspattern/canvas/ports.py` (Phase 1.1)
   - Extracted coordinate mapping logic into `lspattern/canvas/coordinates.py` (Phase 1.2)
+  - Extracted graph composition logic into `lspattern/canvas/composition.py` (Phase 1.3)
   - Moved main canvas implementation to `lspattern/canvas/_canvas_impl.py`
   - Maintained backward compatibility through `lspattern/canvas/__init__.py`
+- Refactored `TemporalLayer` to use `GraphComposer` for graph building operations ([#33](https://github.com/UTokyo-FT-MBQC/ls-pattern-compile/issues/33) Phase 1.3)
 
 ### Removed
 - Deprecated modules `rhg.py` and `ops.py` ([#21](https://github.com/UTokyo-FT-MBQC/ls-pattern-compile/issues/21))

--- a/lspattern/canvas/__init__.py
+++ b/lspattern/canvas/__init__.py
@@ -16,6 +16,9 @@ from lspattern.canvas._canvas_impl import (
     to_temporal_layer,
 )
 
+# Import graph composition
+from lspattern.canvas.composition import GraphComposer
+
 # Import coordinate mapping
 from lspattern.canvas.coordinates import CoordinateMapper
 
@@ -28,6 +31,7 @@ from lspattern.canvas.ports import PortManager
 __all__ = [
     "CompiledRHGCanvas",
     "CoordinateMapper",
+    "GraphComposer",
     "MixedCodeDistanceError",
     "PortManager",
     "RHGCanvas",

--- a/lspattern/canvas/_canvas_impl.py
+++ b/lspattern/canvas/_canvas_impl.py
@@ -385,9 +385,7 @@ class TemporalLayer:
                 g.add_physical_edge(u, v)
                 existing.add(edge)
 
-    def _add_seam_edges(
-        self, g: GraphState, coord_gid_2d: Mapping[tuple[int, int], QubitGroupIdGlobal]
-    ) -> GraphState:
+    def _add_seam_edges(self, g: GraphState, coord_gid_2d: Mapping[tuple[int, int], QubitGroupIdGlobal]) -> GraphState:
         """Add CZ edges across cube-pipe seams within the same temporal layer."""
         # Build XY regions
         cube_xy_all = self._build_xy_regions(dict(coord_gid_2d))

--- a/lspattern/canvas/_canvas_impl.py
+++ b/lspattern/canvas/_canvas_impl.py
@@ -73,7 +73,7 @@ class TemporalLayer:
     flow: FlowAccumulator
     parity: ParityAccumulator
 
-    local_graph: BaseGraphState | None
+    local_graph: GraphState | None
 
     cubes_: dict[PatchCoordGlobal3D, RHGCube]
     pipes_: dict[PipeCoordGlobal3D, RHGPipe]
@@ -386,8 +386,8 @@ class TemporalLayer:
                 existing.add(edge)
 
     def _add_seam_edges(
-        self, g: BaseGraphState, coord_gid_2d: Mapping[tuple[int, int], QubitGroupIdGlobal]
-    ) -> BaseGraphState:
+        self, g: GraphState, coord_gid_2d: Mapping[tuple[int, int], QubitGroupIdGlobal]
+    ) -> GraphState:
         """Add CZ edges across cube-pipe seams within the same temporal layer."""
         # Build XY regions
         cube_xy_all = self._build_xy_regions(dict(coord_gid_2d))
@@ -558,7 +558,7 @@ class CompiledRHGCanvas:
     ----------
     layers : list[TemporalLayer]
         The temporal layers of the canvas.
-    global_graph : BaseGraphState | None
+    global_graph : GraphState | None
         The global graph state after compilation.
     coord2node : dict[PhysCoordGlobal3D, int]
         Mapping from physical coordinates to node IDs.
@@ -580,7 +580,7 @@ class CompiledRHGCanvas:
     layers: list[TemporalLayer]
 
     # Optional/defaulted fields follow
-    global_graph: BaseGraphState | None = None
+    global_graph: GraphState | None = None
     coord2node: dict[PhysCoordGlobal3D, NodeIdLocal] = field(default_factory=dict)
     node2role: dict[NodeIdLocal, str] = field(default_factory=dict)
 
@@ -724,7 +724,7 @@ class CompiledRHGCanvas:
     @staticmethod
     def _create_remapped_graphstate(
         gsrc: BaseGraphState | None, nmap: dict[NodeIdLocal, NodeIdLocal]
-    ) -> BaseGraphState | None:
+    ) -> GraphState | None:
         """Create a remapped GraphState."""
         if gsrc is None:
             return None
@@ -1144,7 +1144,7 @@ def _setup_temporal_connections(
     pipes: list[RHGPipe],
     cgraph: CompiledRHGCanvas,
     next_layer: TemporalLayer,
-    new_graph: BaseGraphState,
+    new_graph: GraphState,
     new_coord2node: dict[PhysCoordGlobal3D, int],
     new_coord2gid: dict[PhysCoordGlobal3D, QubitGroupIdGlobal],
 ) -> None:

--- a/lspattern/canvas/_canvas_impl.py
+++ b/lspattern/canvas/_canvas_impl.py
@@ -253,7 +253,7 @@ class TemporalLayer:
         """Recompute flat cout caches from grouped data."""
         self.port_manager.rebuild_cout_group_cache()
 
-    def _build_graph_from_blocks(self) -> BaseGraphState:
+    def _build_graph_from_blocks(self) -> GraphState:
         """Build the quantum graph state from cubes and pipes."""
         return self.graph_composer.build_graph_from_blocks(self.cubes_, self.pipes_)
 

--- a/lspattern/canvas/_canvas_impl.py
+++ b/lspattern/canvas/_canvas_impl.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from contextlib import suppress
 from dataclasses import dataclass, field
 from operator import itemgetter
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from graphix_zx.graphstate import (
     BaseGraphState,
@@ -385,7 +385,9 @@ class TemporalLayer:
                 g.add_physical_edge(u, v)
                 existing.add(edge)
 
-    def _add_seam_edges(self, g: GraphState, coord_gid_2d: Mapping[tuple[int, int], QubitGroupIdGlobal]) -> GraphState:
+    def _add_seam_edges(
+        self, g: BaseGraphState, coord_gid_2d: Mapping[tuple[int, int], QubitGroupIdGlobal]
+    ) -> GraphState:
         """Add CZ edges across cube-pipe seams within the same temporal layer."""
         # Build XY regions
         cube_xy_all = self._build_xy_regions(dict(coord_gid_2d))
@@ -399,7 +401,7 @@ class TemporalLayer:
 
             self._process_neighbor_connections(u, coord_u, gid_u, cube_xy_all, coord_gid_2d, g, existing)
 
-        return g
+        return cast("GraphState", g)
 
     def compile(self) -> None:
         """Compile the temporal layer into a quantum pattern.
@@ -1142,7 +1144,7 @@ def _setup_temporal_connections(
     pipes: list[RHGPipe],
     cgraph: CompiledRHGCanvas,
     next_layer: TemporalLayer,
-    new_graph: GraphState,
+    new_graph: BaseGraphState,
     new_coord2node: dict[PhysCoordGlobal3D, int],
     new_coord2gid: dict[PhysCoordGlobal3D, QubitGroupIdGlobal],
 ) -> None:

--- a/lspattern/canvas/_canvas_impl.py
+++ b/lspattern/canvas/_canvas_impl.py
@@ -21,6 +21,7 @@ from lspattern.accumulator import FlowAccumulator, ParityAccumulator, ScheduleAc
 from lspattern.blocks.cubes.base import RHGCube
 from lspattern.blocks.pipes.base import RHGPipe
 from lspattern.blocks.pipes.measure import _MeasurePipeBase
+from lspattern.canvas.composition import GraphComposer
 from lspattern.canvas.coordinates import CoordinateMapper
 from lspattern.canvas.ports import PortManager
 from lspattern.consts.consts import DIRECTIONS3D
@@ -65,6 +66,9 @@ class TemporalLayer:
     # Coordinate mapping delegated to CoordinateMapper
     coord_mapper: CoordinateMapper
 
+    # Graph composition delegated to GraphComposer
+    graph_composer: GraphComposer
+
     schedule: ScheduleAccumulator
     flow: FlowAccumulator
     parity: ParityAccumulator
@@ -85,6 +89,7 @@ class TemporalLayer:
         self.lines = []
         self.port_manager = PortManager()
         self.coord_mapper = CoordinateMapper()
+        self.graph_composer = GraphComposer(self.coord_mapper, self.port_manager)
         self.local_graph = None
         # accumulators
         self.schedule = ScheduleAccumulator()
@@ -248,156 +253,9 @@ class TemporalLayer:
         """Recompute flat cout caches from grouped data."""
         self.port_manager.rebuild_cout_group_cache()
 
-    @staticmethod
-    def _compose_single_cube(
-        pos: PatchCoordGlobal3D,  # noqa: ARG004
-        blk: RHGCube,
-        g: BaseGraphState,
-    ) -> tuple[BaseGraphState, Mapping[int, int], Mapping[int, int]]:
-        """Compose a single cube into the graph."""
-        g2 = blk.local_graph
-
-        g_new, node_map1, node_map2 = compose(g, g2)
-        return g_new, node_map1, node_map2
-
-    def _process_cube_coordinates(self, blk: RHGCube, node_map2: Mapping[int, int]) -> None:
-        """Process cube coordinates and roles."""
-        # All blocks now use absolute coordinates - no z_shift needed
-        # Ingest coords/roles
-        for old_n, coord in blk.node2coord.items():
-            new_n = node_map2.get(old_n)
-            if new_n is None:
-                continue
-            x, y, z = int(coord[0]), int(coord[1]), int(coord[2])
-            c_new = PhysCoordGlobal3D((x, y, z))
-            role = blk.node2role.get(old_n)
-            self.coord_mapper.add_node(NodeIdLocal(new_n), c_new, role)
-
-    def _process_pipe_ports(self, pipe_coord: PipeCoordGlobal3D, pipe: RHGPipe, node_map2: Mapping[int, int]) -> None:
-        """Process pipe ports with node mapping."""
-        source, sink = pipe_coord
-        if pipe.in_ports:
-            patch_pos = PatchCoordGlobal3D(source)
-            mapped_nodes = [NodeIdLocal(node_map2[n]) for n in pipe.in_ports if n in node_map2]
-            self.port_manager.add_in_ports(patch_pos, mapped_nodes)
-        if pipe.out_ports:
-            patch_pos = PatchCoordGlobal3D(sink)
-            mapped_nodes = [NodeIdLocal(node_map2[n]) for n in pipe.out_ports if n in node_map2]
-            self.port_manager.add_out_ports(patch_pos, mapped_nodes)
-        if pipe.cout_ports:
-            patch_pos = PatchCoordGlobal3D(sink)
-            for group in pipe.cout_ports:
-                mapped_group: list[NodeIdLocal] = []
-                for node in group:
-                    new_id = node_map2.get(int(node))
-                    if new_id is None:
-                        continue
-                    mapped_group.append(NodeIdLocal(new_id))
-                self.port_manager.register_cout_group(patch_pos, mapped_group)
-
-    def _process_cube_ports(self, pos: tuple[int, int, int], blk: RHGCube, node_map2: Mapping[int, int]) -> None:
-        """Process cube ports."""
-        if blk.in_ports:
-            patch_pos = PatchCoordGlobal3D(pos)
-            mapped_nodes = [NodeIdLocal(node_map2[n]) for n in blk.in_ports if n in node_map2]
-            self.port_manager.add_in_ports(patch_pos, mapped_nodes)
-        if blk.out_ports:
-            patch_pos = PatchCoordGlobal3D(pos)
-            mapped_nodes = [NodeIdLocal(node_map2[n]) for n in blk.out_ports if n in node_map2]
-            self.port_manager.add_out_ports(patch_pos, mapped_nodes)
-        if blk.cout_ports:
-            patch_pos = PatchCoordGlobal3D(pos)
-            for group in blk.cout_ports:
-                mapped_group: list[NodeIdLocal] = []
-                for node in group:
-                    new_id = node_map2.get(int(node))
-                    if new_id is None:
-                        continue
-                    mapped_group.append(NodeIdLocal(new_id))
-                self.port_manager.register_cout_group(patch_pos, mapped_group)
-
     def _build_graph_from_blocks(self) -> BaseGraphState:
         """Build the quantum graph state from cubes and pipes."""
-        # Special case: single block - use its GraphState directly to preserve q_indices
-        if len(self.cubes_) == 1 and len(self.pipes_) == 0:
-            pos, blk = next(iter(self.cubes_.items()))
-            g = blk.local_graph
-            # Process coordinates and ports without composition
-            self._process_cube_coordinates_direct(blk)
-            self._process_cube_ports_direct(pos, blk)
-            return g
-
-        # Multiple blocks case - compose as before
-        g_state: GraphState = GraphState()
-
-        # Compose cube graphs
-        for pos, blk in self.cubes_.items():
-            g_state, node_map1, node_map2 = self._compose_single_cube(pos, blk, g_state)  # pyright: ignore[reportAssignmentType]
-            # Store node mapping for later use in accumulator merging
-            blk.node_map_global = {NodeIdLocal(k): NodeIdLocal(v) for k, v in node_map2.items()}
-            self._remap_node_mappings(node_map1)
-            self._remap_portsets(node_map1)
-            self._process_cube_coordinates(blk, node_map2)
-            self._process_cube_ports(pos, blk, node_map2)
-
-        # Compose pipe graphs (spatial pipes in this layer)
-        return self._compose_pipe_graphs(g_state)
-
-    def _process_cube_coordinates_direct(self, blk: RHGCube) -> None:
-        """Process cube coordinates directly without node mapping."""
-        # All blocks now use absolute coordinates - no z_shift needed
-        # Directly use node coordinates
-        for node, coord in blk.node2coord.items():
-            x, y, z = int(coord[0]), int(coord[1]), int(coord[2])
-            c_new = PhysCoordGlobal3D((x, y, z))
-            role = blk.node2role.get(node)
-            self.coord_mapper.add_node(node, c_new, role)
-
-    def _process_cube_ports_direct(self, pos: PatchCoordGlobal3D, blk: RHGCube) -> None:
-        """Process cube ports directly without node mapping."""
-        # Process input ports
-        input_port_nodes = [NodeIdLocal(node) for node, _ in blk.local_graph.input_node_indices.items()]
-        self.port_manager.add_in_ports(pos, input_port_nodes)
-
-        # Process output ports
-        output_port_nodes = [NodeIdLocal(node) for node, _ in blk.local_graph.output_node_indices.items()]
-        self.port_manager.add_out_ports(pos, output_port_nodes)
-
-        if blk.cout_ports:
-            patch_pos = PatchCoordGlobal3D(pos)
-            for group in blk.cout_ports:
-                mapped_group = [NodeIdLocal(int(node)) for node in group]
-                self.port_manager.register_cout_group(patch_pos, mapped_group)
-
-    def _compose_pipe_graphs(self, g: BaseGraphState) -> BaseGraphState:
-        """Compose pipe graphs into the main graph state."""
-        for pipe_coord, pipe in self.pipes_.items():
-            # Use materialized pipe if local_graph is None
-            pipe_block = pipe
-            g2 = pipe.local_graph
-
-            g_new, node_map1, node_map2 = compose(g, g2)
-            # Store node mapping for later use in accumulator merging
-            pipe.node_map_global = {NodeIdLocal(k): NodeIdLocal(v) for k, v in node_map2.items()}
-            self._remap_node_mappings(node_map1)
-            self._remap_portsets(node_map1)
-            g = g_new
-
-            # All blocks now use absolute coordinates - no z_shift needed
-            for old_n, coord in pipe_block.node2coord.items():
-                new_n = node_map2.get(old_n)
-                if new_n is None:
-                    continue
-                # XY and Z are already in absolute coordinates (shifted in to_temporal_layer)
-                x, y, z = int(coord[0]), int(coord[1]), int(coord[2])
-                c_new = PhysCoordGlobal3D((x, y, z))
-                role = pipe_block.node2role.get(old_n)
-                self.coord_mapper.add_node(NodeIdLocal(new_n), c_new, role)
-
-            # Process pipe ports with node mapping
-            self._process_pipe_ports(pipe_coord, pipe_block, node_map2)
-
-        return g
+        return self.graph_composer.build_graph_from_blocks(self.cubes_, self.pipes_)
 
     def _build_xy_regions(self, coord_gid_2d: dict[tuple[int, int], QubitGroupIdGlobal]) -> set[tuple[int, int]]:
         """Build XY coordinate sets for cubes and pipes."""

--- a/lspattern/canvas/composition.py
+++ b/lspattern/canvas/composition.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from graphix_zx.graphstate import BaseGraphState, GraphState, compose
+from graphix_zx.graphstate import GraphState, compose
 
 from lspattern.mytype import NodeIdLocal, PatchCoordGlobal3D, PhysCoordGlobal3D, PipeCoordGlobal3D
 
@@ -50,8 +50,8 @@ class GraphComposer:
     def compose_single_cube(
         pos: PatchCoordGlobal3D,  # noqa: ARG004
         blk: RHGCube,
-        g: BaseGraphState,
-    ) -> tuple[BaseGraphState, Mapping[int, int], Mapping[int, int]]:
+        g: GraphState,
+    ) -> tuple[GraphState, Mapping[int, int], Mapping[int, int]]:
         """Compose a single cube into the graph.
 
         Parameters
@@ -62,12 +62,12 @@ class GraphComposer:
             be used in future extensions for position-dependent composition logic.
         blk : RHGCube
             The cube block to compose.
-        g : BaseGraphState
+        g : GraphState
             The current graph state.
 
         Returns
         -------
-        tuple[BaseGraphState, Mapping[int, int], Mapping[int, int]]
+        tuple[GraphState, Mapping[int, int], Mapping[int, int]]
             New graph state and node mappings (node_map1, node_map2).
         """
         g2 = blk.local_graph
@@ -201,21 +201,21 @@ class GraphComposer:
 
     def compose_pipe_graphs(
         self,
-        g: BaseGraphState,
+        g: GraphState,
         pipes: dict[PipeCoordGlobal3D, RHGPipe],
-    ) -> BaseGraphState:
+    ) -> GraphState:
         """Compose pipe graphs into the main graph state.
 
         Parameters
         ----------
-        g : BaseGraphState
+        g : GraphState
             The current graph state.
         pipes : dict[PipeCoordGlobal3D, RHGPipe]
             Dictionary of pipe coordinates to pipe blocks.
 
         Returns
         -------
-        BaseGraphState
+        GraphState
             The updated graph state with pipes composed.
 
         Notes
@@ -253,7 +253,7 @@ class GraphComposer:
         self,
         cubes: dict[PatchCoordGlobal3D, RHGCube],
         pipes: dict[PipeCoordGlobal3D, RHGPipe],
-    ) -> BaseGraphState:
+    ) -> GraphState:
         """Build the quantum graph state from cubes and pipes.
 
         Parameters
@@ -265,7 +265,7 @@ class GraphComposer:
 
         Returns
         -------
-        BaseGraphState
+        GraphState
             The composed graph state.
 
         Notes
@@ -288,7 +288,7 @@ class GraphComposer:
 
         # Compose cube graphs
         for pos, blk in cubes.items():
-            g_state, node_map1, node_map2 = self.compose_single_cube(pos, blk, g_state)  # pyright: ignore[reportAssignmentType]
+            g_state, node_map1, node_map2 = self.compose_single_cube(pos, blk, g_state)
             # Store node mapping for later use in accumulator merging
             blk.node_map_global = {NodeIdLocal(k): NodeIdLocal(v) for k, v in node_map2.items()}
             self.coord_mapper.remap_nodes(node_map1)

--- a/lspattern/canvas/composition.py
+++ b/lspattern/canvas/composition.py
@@ -6,9 +6,9 @@ including node mapping, coordinate processing, and port management during graph 
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
-from graphix_zx.graphstate import GraphState, compose
+from graphix_zx.graphstate import BaseGraphState, GraphState, compose
 
 from lspattern.mytype import NodeIdLocal, PatchCoordGlobal3D, PhysCoordGlobal3D, PipeCoordGlobal3D
 
@@ -50,7 +50,7 @@ class GraphComposer:
     def compose_single_cube(
         pos: PatchCoordGlobal3D,  # noqa: ARG004
         blk: RHGCube,
-        g: GraphState,
+        g: BaseGraphState,
     ) -> tuple[GraphState, Mapping[int, int], Mapping[int, int]]:
         """Compose a single cube into the graph.
 
@@ -62,7 +62,7 @@ class GraphComposer:
             be used in future extensions for position-dependent composition logic.
         blk : RHGCube
             The cube block to compose.
-        g : GraphState
+        g : BaseGraphState
             The current graph state.
 
         Returns
@@ -201,14 +201,14 @@ class GraphComposer:
 
     def compose_pipe_graphs(
         self,
-        g: GraphState,
+        g: BaseGraphState,
         pipes: dict[PipeCoordGlobal3D, RHGPipe],
     ) -> GraphState:
         """Compose pipe graphs into the main graph state.
 
         Parameters
         ----------
-        g : GraphState
+        g : BaseGraphState
             The current graph state.
         pipes : dict[PipeCoordGlobal3D, RHGPipe]
             Dictionary of pipe coordinates to pipe blocks.
@@ -247,7 +247,7 @@ class GraphComposer:
             # Process pipe ports with node mapping
             self.process_pipe_ports(pipe_coord, pipe, node_map2)
 
-        return g
+        return cast("GraphState", g)
 
     def build_graph_from_blocks(
         self,

--- a/lspattern/canvas/composition.py
+++ b/lspattern/canvas/composition.py
@@ -1,0 +1,293 @@
+"""Graph composition logic for RHG canvas temporal layers.
+
+This module handles the composition of graph states from RHG blocks (cubes and pipes),
+including node mapping, coordinate processing, and port management during graph merging.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from graphix_zx.graphstate import BaseGraphState, GraphState, compose
+
+from lspattern.mytype import NodeIdLocal, PatchCoordGlobal3D, PhysCoordGlobal3D, PipeCoordGlobal3D
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from lspattern.blocks.cubes.base import RHGCube
+    from lspattern.blocks.pipes.base import RHGPipe
+    from lspattern.canvas.coordinates import CoordinateMapper
+    from lspattern.canvas.ports import PortManager
+
+
+class GraphComposer:
+    """Handles graph composition logic for temporal layers.
+
+    This class encapsulates the logic for composing graph states from RHG blocks,
+    managing node remapping, coordinate processing, and port management during
+    the composition process.
+    """
+
+    def __init__(
+        self,
+        coord_mapper: CoordinateMapper,
+        port_manager: PortManager,
+    ) -> None:
+        """Initialize the graph composer.
+
+        Parameters
+        ----------
+        coord_mapper : CoordinateMapper
+            Coordinate mapper for managing node-coordinate mappings.
+        port_manager : PortManager
+            Port manager for managing input/output/cout ports.
+        """
+        self.coord_mapper = coord_mapper
+        self.port_manager = port_manager
+
+    @staticmethod
+    def compose_single_cube(
+        pos: PatchCoordGlobal3D,  # noqa: ARG004
+        blk: RHGCube,
+        g: BaseGraphState,
+    ) -> tuple[BaseGraphState, Mapping[int, int], Mapping[int, int]]:
+        """Compose a single cube into the graph.
+
+        Parameters
+        ----------
+        pos : PatchCoordGlobal3D
+            Position of the cube (unused but kept for API consistency).
+        blk : RHGCube
+            The cube block to compose.
+        g : BaseGraphState
+            The current graph state.
+
+        Returns
+        -------
+        tuple[BaseGraphState, Mapping[int, int], Mapping[int, int]]
+            New graph state and node mappings (node_map1, node_map2).
+        """
+        g2 = blk.local_graph
+
+        g_new, node_map1, node_map2 = compose(g, g2)
+        return g_new, node_map1, node_map2
+
+    def process_cube_coordinates(self, blk: RHGCube, node_map2: Mapping[int, int]) -> None:
+        """Process cube coordinates and roles with node mapping.
+
+        Parameters
+        ----------
+        blk : RHGCube
+            The cube block whose coordinates to process.
+        node_map2 : Mapping[int, int]
+            Node mapping from local to global node IDs.
+        """
+        # All blocks now use absolute coordinates - no z_shift needed
+        # Ingest coords/roles
+        for old_n, coord in blk.node2coord.items():
+            new_n = node_map2.get(old_n)
+            if new_n is None:
+                continue
+            x, y, z = int(coord[0]), int(coord[1]), int(coord[2])
+            c_new = PhysCoordGlobal3D((x, y, z))
+            role = blk.node2role.get(old_n)
+            self.coord_mapper.add_node(NodeIdLocal(new_n), c_new, role)
+
+    def process_cube_coordinates_direct(self, blk: RHGCube) -> None:
+        """Process cube coordinates directly without node mapping.
+
+        Used when there's only a single cube in the layer.
+
+        Parameters
+        ----------
+        blk : RHGCube
+            The cube block whose coordinates to process.
+        """
+        # All blocks now use absolute coordinates - no z_shift needed
+        # Directly use node coordinates
+        for node, coord in blk.node2coord.items():
+            x, y, z = int(coord[0]), int(coord[1]), int(coord[2])
+            c_new = PhysCoordGlobal3D((x, y, z))
+            role = blk.node2role.get(node)
+            self.coord_mapper.add_node(node, c_new, role)
+
+    def process_cube_ports(self, pos: PatchCoordGlobal3D, blk: RHGCube, node_map2: Mapping[int, int]) -> None:
+        """Process cube ports with node mapping.
+
+        Parameters
+        ----------
+        pos : PatchCoordGlobal3D
+            Position of the cube.
+        blk : RHGCube
+            The cube block whose ports to process.
+        node_map2 : Mapping[int, int]
+            Node mapping from local to global node IDs.
+        """
+        if blk.in_ports:
+            patch_pos = PatchCoordGlobal3D(pos)
+            mapped_nodes = [NodeIdLocal(node_map2[n]) for n in blk.in_ports if n in node_map2]
+            self.port_manager.add_in_ports(patch_pos, mapped_nodes)
+        if blk.out_ports:
+            patch_pos = PatchCoordGlobal3D(pos)
+            mapped_nodes = [NodeIdLocal(node_map2[n]) for n in blk.out_ports if n in node_map2]
+            self.port_manager.add_out_ports(patch_pos, mapped_nodes)
+        if blk.cout_ports:
+            patch_pos = PatchCoordGlobal3D(pos)
+            for group in blk.cout_ports:
+                mapped_group: list[NodeIdLocal] = []
+                for node in group:
+                    new_id = node_map2.get(int(node))
+                    if new_id is None:
+                        continue
+                    mapped_group.append(NodeIdLocal(new_id))
+                self.port_manager.register_cout_group(patch_pos, mapped_group)
+
+    def process_cube_ports_direct(self, pos: PatchCoordGlobal3D, blk: RHGCube) -> None:
+        """Process cube ports directly without node mapping.
+
+        Used when there's only a single cube in the layer.
+
+        Parameters
+        ----------
+        pos : PatchCoordGlobal3D
+            Position of the cube.
+        blk : RHGCube
+            The cube block whose ports to process.
+        """
+        # Process input ports
+        input_port_nodes = [NodeIdLocal(node) for node, _ in blk.local_graph.input_node_indices.items()]
+        self.port_manager.add_in_ports(pos, input_port_nodes)
+
+        # Process output ports
+        output_port_nodes = [NodeIdLocal(node) for node, _ in blk.local_graph.output_node_indices.items()]
+        self.port_manager.add_out_ports(pos, output_port_nodes)
+
+        if blk.cout_ports:
+            patch_pos = PatchCoordGlobal3D(pos)
+            for group in blk.cout_ports:
+                mapped_group = [NodeIdLocal(int(node)) for node in group]
+                self.port_manager.register_cout_group(patch_pos, mapped_group)
+
+    def process_pipe_ports(self, pipe_coord: PipeCoordGlobal3D, pipe: RHGPipe, node_map2: Mapping[int, int]) -> None:
+        """Process pipe ports with node mapping.
+
+        Parameters
+        ----------
+        pipe_coord : PipeCoordGlobal3D
+            Coordinate of the pipe (source, sink).
+        pipe : RHGPipe
+            The pipe block whose ports to process.
+        node_map2 : Mapping[int, int]
+            Node mapping from local to global node IDs.
+        """
+        source, sink = pipe_coord
+        if pipe.in_ports:
+            patch_pos = PatchCoordGlobal3D(source)
+            mapped_nodes = [NodeIdLocal(node_map2[n]) for n in pipe.in_ports if n in node_map2]
+            self.port_manager.add_in_ports(patch_pos, mapped_nodes)
+        if pipe.out_ports:
+            patch_pos = PatchCoordGlobal3D(sink)
+            mapped_nodes = [NodeIdLocal(node_map2[n]) for n in pipe.out_ports if n in node_map2]
+            self.port_manager.add_out_ports(patch_pos, mapped_nodes)
+        if pipe.cout_ports:
+            patch_pos = PatchCoordGlobal3D(sink)
+            for group in pipe.cout_ports:
+                mapped_group: list[NodeIdLocal] = []
+                for node in group:
+                    new_id = node_map2.get(int(node))
+                    if new_id is None:
+                        continue
+                    mapped_group.append(NodeIdLocal(new_id))
+                self.port_manager.register_cout_group(patch_pos, mapped_group)
+
+    def compose_pipe_graphs(
+        self,
+        g: BaseGraphState,
+        pipes: dict[PipeCoordGlobal3D, RHGPipe],
+    ) -> BaseGraphState:
+        """Compose pipe graphs into the main graph state.
+
+        Parameters
+        ----------
+        g : BaseGraphState
+            The current graph state.
+        pipes : dict[PipeCoordGlobal3D, RHGPipe]
+            Dictionary of pipe coordinates to pipe blocks.
+
+        Returns
+        -------
+        BaseGraphState
+            The updated graph state with pipes composed.
+        """
+        for pipe_coord, pipe in pipes.items():
+            # Use materialized pipe if local_graph is None
+            pipe_block = pipe
+            g2 = pipe.local_graph
+
+            g_new, node_map1, node_map2 = compose(g, g2)
+            # Store node mapping for later use in accumulator merging
+            pipe.node_map_global = {NodeIdLocal(k): NodeIdLocal(v) for k, v in node_map2.items()}
+            self.coord_mapper.remap_nodes(node_map1)
+            self.port_manager.remap_ports(node_map1)
+            g = g_new
+
+            # All blocks now use absolute coordinates - no z_shift needed
+            for old_n, coord in pipe_block.node2coord.items():
+                new_n = node_map2.get(old_n)
+                if new_n is None:
+                    continue
+                # XY and Z are already in absolute coordinates (shifted in to_temporal_layer)
+                x, y, z = int(coord[0]), int(coord[1]), int(coord[2])
+                c_new = PhysCoordGlobal3D((x, y, z))
+                role = pipe_block.node2role.get(old_n)
+                self.coord_mapper.add_node(NodeIdLocal(new_n), c_new, role)
+
+            # Process pipe ports with node mapping
+            self.process_pipe_ports(pipe_coord, pipe_block, node_map2)
+
+        return g
+
+    def build_graph_from_blocks(
+        self,
+        cubes: dict[PatchCoordGlobal3D, RHGCube],
+        pipes: dict[PipeCoordGlobal3D, RHGPipe],
+    ) -> BaseGraphState:
+        """Build the quantum graph state from cubes and pipes.
+
+        Parameters
+        ----------
+        cubes : dict[PatchCoordGlobal3D, RHGCube]
+            Dictionary of cube coordinates to cube blocks.
+        pipes : dict[PipeCoordGlobal3D, RHGPipe]
+            Dictionary of pipe coordinates to pipe blocks.
+
+        Returns
+        -------
+        BaseGraphState
+            The composed graph state.
+        """
+        # Special case: single block - use its GraphState directly to preserve q_indices
+        if len(cubes) == 1 and len(pipes) == 0:
+            pos, blk = next(iter(cubes.items()))
+            g = blk.local_graph
+            # Process coordinates and ports without composition
+            self.process_cube_coordinates_direct(blk)
+            self.process_cube_ports_direct(pos, blk)
+            return g
+
+        # Multiple blocks case - compose as before
+        g_state: GraphState = GraphState()
+
+        # Compose cube graphs
+        for pos, blk in cubes.items():
+            g_state, node_map1, node_map2 = self.compose_single_cube(pos, blk, g_state)  # pyright: ignore[reportAssignmentType]
+            # Store node mapping for later use in accumulator merging
+            blk.node_map_global = {NodeIdLocal(k): NodeIdLocal(v) for k, v in node_map2.items()}
+            self.coord_mapper.remap_nodes(node_map1)
+            self.port_manager.remap_ports(node_map1)
+            self.process_cube_coordinates(blk, node_map2)
+            self.process_cube_ports(pos, blk, node_map2)
+
+        # Compose pipe graphs (spatial pipes in this layer)
+        return self.compose_pipe_graphs(g_state, pipes)

--- a/tests/canvas/test_composition.py
+++ b/tests/canvas/test_composition.py
@@ -1,0 +1,20 @@
+"""Unit tests for GraphComposer class."""
+
+from __future__ import annotations
+
+from lspattern.canvas.composition import GraphComposer
+from lspattern.canvas.coordinates import CoordinateMapper
+from lspattern.canvas.ports import PortManager
+
+
+class TestGraphComposerBasic:
+    """Test basic GraphComposer functionality."""
+
+    def test_initialization(self) -> None:
+        """Test GraphComposer initializes correctly with dependencies."""
+        coord_mapper = CoordinateMapper()
+        port_manager = PortManager()
+        composer = GraphComposer(coord_mapper, port_manager)
+
+        assert composer.coord_mapper is coord_mapper
+        assert composer.port_manager is port_manager


### PR DESCRIPTION
## Summary

This PR implements **Phase 1.3** of the canvas refactoring effort (Issue #33), extracting graph composition logic into a dedicated `GraphComposer` class for improved modularity and testability.

## Changes

### New Files
- **`lspattern/canvas/composition.py`**: New module containing `GraphComposer` class
  - Encapsulates all graph composition logic from `TemporalLayer`
  - Methods for composing cubes and pipes into quantum graph states
  - Handles node remapping, coordinate processing, and port management

### Modified Files
- **`lspattern/canvas/_canvas_impl.py`**: Refactored `TemporalLayer` class
  - Added `GraphComposer` instance in `__init__`
  - Replaced inline graph composition methods with delegation to `GraphComposer`
  - Simplified `_build_graph_from_blocks()` to single line delegation
  
- **`lspattern/canvas/__init__.py`**: Updated exports
  - Added `GraphComposer` to public API
  
- **`CHANGELOG.md`**: Documented Phase 1.3 changes

### Test Files
- **`tests/canvas/test_composition.py`**: Basic unit tests for `GraphComposer`
  - Tests initialization and dependency injection
  - More comprehensive tests can be added in future PRs

## GraphComposer API

```python
class GraphComposer:
    def __init__(coord_mapper: CoordinateMapper, port_manager: PortManager)
    
    # Static method for cube composition
    @staticmethod
    def compose_single_cube(pos, blk, g) -> tuple[BaseGraphState, Mapping, Mapping]
    
    # Coordinate processing methods
    def process_cube_coordinates(blk, node_map2) -> None
    def process_cube_coordinates_direct(blk) -> None
    
    # Port processing methods
    def process_cube_ports(pos, blk, node_map2) -> None
    def process_cube_ports_direct(pos, blk) -> None
    def process_pipe_ports(pipe_coord, pipe, node_map2) -> None
    
    # Graph composition methods
    def compose_pipe_graphs(g, pipes) -> BaseGraphState
    def build_graph_from_blocks(cubes, pipes) -> BaseGraphState
```

## Benefits

1. **Improved Modularity**: Graph composition logic now resides in a dedicated class
2. **Better Testability**: `GraphComposer` can be tested in isolation from `TemporalLayer`
3. **Cleaner Separation of Concerns**: `TemporalLayer` delegates graph operations to `GraphComposer`
4. **Maintained Backward Compatibility**: All existing tests pass without modification

## Testing

- ✅ All existing tests pass (94 passed, 2 skipped)
- ✅ New basic unit test for `GraphComposer` initialization
- ✅ Type checking: `mypy` and `pyright` pass with no errors
- ✅ Linting: `ruff check` and `ruff format` pass

## Related Issues

- Addresses Phase 1.3 of #33

## Next Steps

After this PR, the remaining phases are:
- **Phase 1.4**: Extract seam edge generation logic
- **Phase 1.5**: Reorganize canvas module into subpackage structure
- **Phase 2**: Add comprehensive unit tests for all extracted modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)