### PR TITLE
Fix patch expansion X and Z boundary configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Simplified `num_unit_layers` handling in cout computation methods
 
 ### Fixed
+- Fix patch expansion X and Z boundary YAML configurations
+  - Corrected block types and logical observable settings in `patch_expansion_x.yml`
+  - Fixed Z boundary expansion configuration in `patch_expansion_z.yml`
+  - Minimized depth from z=3 to z=2 for both configurations
 - Fix detector position logic for transversal measurement layers
 - Fix `invert_ancilla_order` flag not being applied to syndrome measurement registration when `ancilla=false` and `skip_syndrome=false`
 - Fix duplicate offset calculation in pipe fragment generation that caused pipes to overlap with cube nodes

--- a/examples/design/patch_expansion_x.yml
+++ b/examples/design/patch_expansion_x.yml
@@ -5,40 +5,35 @@ layout: rotated_surface_code # required
 
 cube:
   - position: [0, 0, 0]
-    block: InitPlusBlock
+    block: InitZeroBlock
     boundary: XXZZ
   - position: [0, 0, 1]
     block: MemoryBlock
-    boundary: XXZZ
+    boundary: XXZO
   - position: [1, 0, 1]
     block: InitZeroBlock
-    boundary: XXZZ
+    boundary: XXOZ
   - position: [0, 0, 2]
-    block: MemoryBlock
+    block: MeasureZBlock
     boundary: XXZO
+    logical_observables: RL
   - position: [1, 0, 2]
-    block: InitPlusBlock
+    block: MeasureZBlock
     boundary: XXOZ
-  - position: [0, 0, 3]
-    block: MeasureXBlock
-    boundary: XXZO
-    logical_observables: TB
-  - position: [1, 0, 3]
-    block: MeasureXBlock
-    boundary: XXOZ
-    logical_observables: TB
+    logical_observables: RL
 
 pipe:
-  - start: [0, 0, 2]
-    end: [1, 0, 2]
+  - start: [0, 0, 1]
+    end: [1, 0, 1]
     block: InitZeroBlock
     boundary: XXOO
     logical_observables: Z
-  - start: [0, 0, 3]
-    end: [1, 0, 3]
-    block: MeasureXBlock
+  - start: [0, 0, 2]
+    end: [1, 0, 2]
+    block: MeasureZBlock
     boundary: XXOO
-    logical_observables: TB
+    logical_observables: RL
 
 logical_observables:
-  - cube: [[0, 0, 3]]
+  - cube: [[0, 0, 2], [1, 0, 2]] # cube
+    pipe: [[[0, 0, 2], [1, 0, 2]]]

--- a/examples/design/patch_expansion_z.yml
+++ b/examples/design/patch_expansion_z.yml
@@ -9,37 +9,31 @@ cube:
     boundary: ZZXX
   - position: [0, 0, 1]
     block: MemoryBlock
-    boundary: ZZXX
-  # - position: [1, 0, 1]
-  #   block: InitPlusBlock
-  #   boundary: ZZXX
-  - position: [0, 0, 2]
-    block: MemoryBlock
     boundary: ZZXO
-  - position: [1, 0, 2]
+  - position: [1, 0, 1]
     block: InitPlusBlock
     boundary: ZZOX
-  - position: [0, 0, 3]
+  - position: [0, 0, 2]
     block: MeasureXBlock
     boundary: ZZXO
     logical_observables: LR
-  - position: [1, 0, 3]
+  - position: [1, 0, 2]
     block: MeasureXBlock
     boundary: ZZOX
     logical_observables: LR
 
 pipe:
-  - start: [0, 0, 2]
-    end: [1, 0, 2]
+  - start: [0, 0, 1]
+    end: [1, 0, 1]
     block: InitPlusBlock
     boundary: ZZOO
     logical_observables: Z
-  - start: [0, 0, 3]
-    end: [1, 0, 3]
+  - start: [0, 0, 2]
+    end: [1, 0, 2]
     block: MeasureXBlock
     boundary: ZZOO
     logical_observables: LR
 
 logical_observables:
-  - cube: [[0, 0, 3], [1, 0, 3]] # cube
-    pipe: [[[0, 0, 3], [1, 0, 3]]]
+  - cube: [[0, 0, 2], [1, 0, 2]] # cube
+    pipe: [[[0, 0, 2], [1, 0, 2]]]

--- a/tests/test_design_yaml_integration.py
+++ b/tests/test_design_yaml_integration.py
@@ -23,8 +23,6 @@ _CANVAS_YMLS = sorted(p.name for p in _DESIGN_DIR.glob("*.yml"))
 # Known failing canvases — to be fixed in future work.
 _KNOWN_FAILURES: dict[str, str] = {
     "graph_block_canvas.yml": "non-deterministic observables",
-    "patch_expansion_x.yml": "cycle detected in feedforward graph",
-    "patch_expansion_z.yml": "non-deterministic detectors",
 }
 
 


### PR DESCRIPTION
## Summary
- Fixed patch expansion X boundary YAML configuration (`patch_expansion_x.yml`)
  - Corrected block types (InitPlus→InitZero, Memory→MeasureZ, etc.)
  - Fixed logical observable settings (TB→RL)
- Fixed patch expansion Z boundary YAML configuration (`patch_expansion_z.yml`)
  - Removed unnecessary memory blocks
- Minimized depth from z=3 to z=2 for both configurations
- Removed `patch_expansion_x` and `patch_expansion_z` from known failure cases in integration tests

## Test plan
- [x] Run `pytest tests/test_design_yaml_integration.py` to verify both patch expansion tests pass
- [x] Verify `patch_expansion_x` and `patch_expansion_z` are no longer in the known failures list

🤖 Generated with [Claude Code](https://claude.com/claude-code)