### PR TITLE
Upgrade LasSynth importer: Hadamard blocks, bulk measure, and pipe simplification

### DIFF
--- a/lspattern/importer/demo/cnot_spec_0.yml
+++ b/lspattern/importer/demo/cnot_spec_0.yml
@@ -13,7 +13,7 @@ cube:
   - 1
   - 0
   block: InitZeroBlock
-  boundary: ZZXX
+  boundary: XXZZ
 - position:
   - 0
   - 0
@@ -24,50 +24,49 @@ cube:
   - 1
   - 0
   - 1
-  block: MemoryBlock
-  boundary: ZZOX
+  block: HadamardBlock
+  boundary: XXOZ
+  invert_ancilla_order: true
 - position:
   - 0
   - 1
   - 1
-  block: MemoryBlock
-  boundary: ZZXX
+  block: HadamardBlock
+  boundary: XXZZ
+  invert_ancilla_order: true
 - position:
   - 0
   - 0
   - 2
-  block: MemoryBlock
+  block: MeasureBulkXBlock
   boundary: ZOXX
 - position:
   - 1
   - 0
   - 2
-  block: MemoryBlock
-  boundary: ZZXX
+  block: HadamardBlock
+  boundary: XXZZ
 - position:
   - 0
   - 1
   - 2
   block: MemoryBlock
   boundary: OZXX
-- position:
-  - 0
-  - 0
-  - 3
-  block: MeasureXBlock
-  boundary: ZZXX
+  invert_ancilla_order: true
 - position:
   - 1
   - 0
   - 3
   block: MeasureZBlock
   boundary: ZZXX
+  logical_observables: TB
 - position:
   - 0
   - 1
   - 3
   block: MeasureZBlock
-  boundary: ZZXX
+  boundary: XXZZ
+  invert_ancilla_order: true
 pipe:
 - start:
   - 0
@@ -77,7 +76,7 @@ pipe:
   - 1
   - 0
   - 1
-  block: ShortXMemoryBlock
+  block: ShortZMemoryBlock
   boundary: ZZOO
 - start:
   - 0
@@ -87,5 +86,10 @@ pipe:
   - 0
   - 1
   - 2
-  block: ShortZMemoryBlock
+  block: ShortXMemoryBlock
   boundary: OOXX
+logical_observables:
+- cube:
+  - - 1
+    - 0
+    - 3

--- a/lspattern/importer/demo/cnot_spec_0.yml
+++ b/lspattern/importer/demo/cnot_spec_0.yml
@@ -77,17 +77,7 @@ pipe:
   - 1
   - 0
   - 1
-  block: InitPlusBlock
-  boundary: ZZOO
-- start:
-  - 0
-  - 0
-  - 2
-  end:
-  - 1
-  - 0
-  - 2
-  block: MeasureXBlock
+  block: ShortXMemoryBlock
   boundary: ZZOO
 - start:
   - 0
@@ -97,15 +87,5 @@ pipe:
   - 0
   - 1
   - 2
-  block: InitZeroBlock
-  boundary: OOXX
-- start:
-  - 0
-  - 0
-  - 3
-  end:
-  - 0
-  - 1
-  - 3
-  block: MeasureZBlock
+  block: ShortZMemoryBlock
   boundary: OOXX

--- a/lspattern/importer/demo/cnot_spec_1.yml
+++ b/lspattern/importer/demo/cnot_spec_1.yml
@@ -77,17 +77,7 @@ pipe:
   - 1
   - 0
   - 1
-  block: InitPlusBlock
-  boundary: ZZOO
-- start:
-  - 0
-  - 0
-  - 2
-  end:
-  - 1
-  - 0
-  - 2
-  block: MeasureXBlock
+  block: ShortXMemoryBlock
   boundary: ZZOO
 - start:
   - 0
@@ -97,15 +87,5 @@ pipe:
   - 0
   - 1
   - 2
-  block: InitZeroBlock
-  boundary: OOXX
-- start:
-  - 0
-  - 0
-  - 3
-  end:
-  - 0
-  - 1
-  - 3
-  block: MeasureZBlock
+  block: ShortZMemoryBlock
   boundary: OOXX

--- a/lspattern/importer/demo/cnot_spec_1.yml
+++ b/lspattern/importer/demo/cnot_spec_1.yml
@@ -13,7 +13,7 @@ cube:
   - 1
   - 0
   block: InitZeroBlock
-  boundary: ZZXX
+  boundary: XXZZ
 - position:
   - 0
   - 0
@@ -24,50 +24,50 @@ cube:
   - 1
   - 0
   - 1
-  block: MemoryBlock
-  boundary: ZZOX
+  block: HadamardBlock
+  boundary: XXOZ
+  invert_ancilla_order: true
 - position:
   - 0
   - 1
   - 1
-  block: MemoryBlock
-  boundary: ZZXX
+  block: HadamardBlock
+  boundary: XXZZ
+  invert_ancilla_order: true
 - position:
   - 0
   - 0
   - 2
-  block: MemoryBlock
+  block: MeasureBulkXBlock
   boundary: ZOXX
 - position:
   - 1
   - 0
   - 2
-  block: MemoryBlock
-  boundary: ZZXX
+  block: HadamardBlock
+  boundary: XXZZ
 - position:
   - 0
   - 1
   - 2
   block: MemoryBlock
   boundary: OZXX
-- position:
-  - 0
-  - 0
-  - 3
-  block: MeasureXBlock
-  boundary: ZZXX
+  invert_ancilla_order: true
 - position:
   - 1
   - 0
   - 3
   block: MeasureZBlock
   boundary: ZZXX
+  logical_observables: TB
 - position:
   - 0
   - 1
   - 3
   block: MeasureZBlock
-  boundary: ZZXX
+  boundary: XXZZ
+  invert_ancilla_order: true
+  logical_observables: TB
 pipe:
 - start:
   - 0
@@ -77,8 +77,12 @@ pipe:
   - 1
   - 0
   - 1
-  block: ShortXMemoryBlock
+  block: ShortZMemoryBlock
   boundary: ZZOO
+  logical_observables:
+  - token: Z
+    layer: 0
+    sublayer: 1
 - start:
   - 0
   - 0
@@ -87,5 +91,30 @@ pipe:
   - 0
   - 1
   - 2
-  block: ShortZMemoryBlock
+  block: ShortXMemoryBlock
   boundary: OOXX
+  logical_observables:
+  - token: TB
+    layer: -1
+    sublayer: 1
+logical_observables:
+- cube:
+  - - 1
+    - 0
+    - 3
+  - - 0
+    - 1
+    - 3
+  pipe:
+  - - - 0
+      - 0
+      - 1
+    - - 1
+      - 0
+      - 1
+  - - - 0
+      - 0
+      - 2
+    - - 0
+      - 1
+      - 2

--- a/lspattern/importer/demo/cnot_spec_2.yml
+++ b/lspattern/importer/demo/cnot_spec_2.yml
@@ -77,17 +77,7 @@ pipe:
   - 1
   - 0
   - 1
-  block: InitPlusBlock
-  boundary: ZZOO
-- start:
-  - 0
-  - 0
-  - 2
-  end:
-  - 1
-  - 0
-  - 2
-  block: MeasureXBlock
+  block: ShortXMemoryBlock
   boundary: ZZOO
 - start:
   - 0
@@ -97,15 +87,5 @@ pipe:
   - 0
   - 1
   - 2
-  block: InitZeroBlock
-  boundary: OOXX
-- start:
-  - 0
-  - 0
-  - 3
-  end:
-  - 0
-  - 1
-  - 3
-  block: MeasureZBlock
+  block: ShortZMemoryBlock
   boundary: OOXX

--- a/lspattern/importer/demo/cnot_spec_2.yml
+++ b/lspattern/importer/demo/cnot_spec_2.yml
@@ -13,7 +13,7 @@ cube:
   - 1
   - 0
   block: InitZeroBlock
-  boundary: ZZXX
+  boundary: XXZZ
 - position:
   - 0
   - 0
@@ -24,50 +24,50 @@ cube:
   - 1
   - 0
   - 1
-  block: MemoryBlock
-  boundary: ZZOX
+  block: HadamardBlock
+  boundary: XXOZ
+  invert_ancilla_order: true
 - position:
   - 0
   - 1
   - 1
-  block: MemoryBlock
-  boundary: ZZXX
+  block: HadamardBlock
+  boundary: XXZZ
+  invert_ancilla_order: true
 - position:
   - 0
   - 0
   - 2
-  block: MemoryBlock
+  block: MeasureBulkXBlock
   boundary: ZOXX
 - position:
   - 1
   - 0
   - 2
-  block: MemoryBlock
-  boundary: ZZXX
+  block: HadamardBlock
+  boundary: XXZZ
 - position:
   - 0
   - 1
   - 2
   block: MemoryBlock
   boundary: OZXX
-- position:
-  - 0
-  - 0
-  - 3
-  block: MeasureXBlock
-  boundary: ZZXX
+  invert_ancilla_order: true
 - position:
   - 1
   - 0
   - 3
   block: MeasureXBlock
   boundary: ZZXX
+  logical_observables: RL
 - position:
   - 0
   - 1
   - 3
   block: MeasureXBlock
-  boundary: ZZXX
+  boundary: XXZZ
+  invert_ancilla_order: true
+  logical_observables: RL
 pipe:
 - start:
   - 0
@@ -77,8 +77,12 @@ pipe:
   - 1
   - 0
   - 1
-  block: ShortXMemoryBlock
+  block: ShortZMemoryBlock
   boundary: ZZOO
+  logical_observables:
+  - token: RL
+    layer: -1
+    sublayer: 2
 - start:
   - 0
   - 0
@@ -87,5 +91,30 @@ pipe:
   - 0
   - 1
   - 2
-  block: ShortZMemoryBlock
+  block: ShortXMemoryBlock
   boundary: OOXX
+  logical_observables:
+  - token: X
+    layer: 0
+    sublayer: 2
+logical_observables:
+- cube:
+  - - 1
+    - 0
+    - 3
+  - - 0
+    - 1
+    - 3
+  pipe:
+  - - - 0
+      - 0
+      - 1
+    - - 1
+      - 0
+      - 1
+  - - - 0
+      - 0
+      - 2
+    - - 0
+      - 1
+      - 2

--- a/lspattern/importer/demo/cnot_spec_3.yml
+++ b/lspattern/importer/demo/cnot_spec_3.yml
@@ -13,7 +13,7 @@ cube:
   - 1
   - 0
   block: InitPlusBlock
-  boundary: ZZXX
+  boundary: XXZZ
 - position:
   - 0
   - 0
@@ -24,38 +24,35 @@ cube:
   - 1
   - 0
   - 1
-  block: MemoryBlock
-  boundary: ZZOX
+  block: HadamardBlock
+  boundary: XXOZ
+  invert_ancilla_order: true
 - position:
   - 0
   - 1
   - 1
-  block: MemoryBlock
-  boundary: ZZXX
+  block: HadamardBlock
+  boundary: XXZZ
+  invert_ancilla_order: true
 - position:
   - 0
   - 0
   - 2
-  block: MemoryBlock
+  block: MeasureBulkXBlock
   boundary: ZOXX
 - position:
   - 1
   - 0
   - 2
-  block: MemoryBlock
-  boundary: ZZXX
+  block: HadamardBlock
+  boundary: XXZZ
 - position:
   - 0
   - 1
   - 2
   block: MemoryBlock
   boundary: OZXX
-- position:
-  - 0
-  - 0
-  - 3
-  block: MeasureXBlock
-  boundary: ZZXX
+  invert_ancilla_order: true
 - position:
   - 1
   - 0
@@ -67,7 +64,9 @@ cube:
   - 1
   - 3
   block: MeasureXBlock
-  boundary: ZZXX
+  boundary: XXZZ
+  invert_ancilla_order: true
+  logical_observables: RL
 pipe:
 - start:
   - 0
@@ -77,7 +76,7 @@ pipe:
   - 1
   - 0
   - 1
-  block: ShortXMemoryBlock
+  block: ShortZMemoryBlock
   boundary: ZZOO
 - start:
   - 0
@@ -87,5 +86,10 @@ pipe:
   - 0
   - 1
   - 2
-  block: ShortZMemoryBlock
+  block: ShortXMemoryBlock
   boundary: OOXX
+logical_observables:
+- cube:
+  - - 0
+    - 1
+    - 3

--- a/lspattern/importer/demo/cnot_spec_3.yml
+++ b/lspattern/importer/demo/cnot_spec_3.yml
@@ -77,17 +77,7 @@ pipe:
   - 1
   - 0
   - 1
-  block: InitPlusBlock
-  boundary: ZZOO
-- start:
-  - 0
-  - 0
-  - 2
-  end:
-  - 1
-  - 0
-  - 2
-  block: MeasureXBlock
+  block: ShortXMemoryBlock
   boundary: ZZOO
 - start:
   - 0
@@ -97,15 +87,5 @@ pipe:
   - 0
   - 1
   - 2
-  block: InitZeroBlock
-  boundary: OOXX
-- start:
-  - 0
-  - 0
-  - 3
-  end:
-  - 0
-  - 1
-  - 3
-  block: MeasureZBlock
+  block: ShortZMemoryBlock
   boundary: OOXX

--- a/lspattern/importer/las.py
+++ b/lspattern/importer/las.py
@@ -71,6 +71,65 @@ def _base_boundary(z_dir: str) -> list[str]:
     return list("ZZXX")
 
 
+def _color_kp_to_boundary(color_kp: int, inverted: bool = False) -> list[str] | None:
+    """Return [T,B,L,R] boundary chars based on ColorKP value.
+
+    ColorKP = 0 -> ZZXX (or XXZZ if inverted)
+    ColorKP = 1 -> XXZZ (or ZZXX if inverted)
+    ColorKP = -1 -> None (refer to cube below)
+
+    Parameters
+    ----------
+    color_kp : int
+        ColorKP value (0, 1, or -1).
+    inverted : bool
+        If True, invert the boundary mapping (used after Hadamard).
+    """
+    if color_kp == -1:
+        return None  # refer to cube below
+
+    if inverted:
+        # Invert the mapping
+        return list("XXZZ") if color_kp == 0 else list("ZZXX")
+    # Normal mapping
+    return list("ZZXX") if color_kp == 0 else list("XXZZ")
+
+
+def _resolve_cube_boundary(
+    coord: Coord3,
+    color_kp: list[Any],
+    n_i: int,
+    n_j: int,
+    n_k: int,
+    boundaries: dict[Coord3, list[str]],
+    port_zdir_map: dict[Coord3, str],
+    default_zdir: str,
+    inverted: bool = False,
+) -> list[str]:
+    """Resolve boundary for a single cube based on ColorKP.
+
+    Parameters
+    ----------
+    inverted : bool
+        If True, invert the boundary mapping (used after Hadamard).
+    """
+    i, j, k = coord
+    kp_val = _get_color_kp(i, j, k, color_kp, n_i, n_j, n_k)
+    boundary = _color_kp_to_boundary(kp_val, inverted=inverted)
+
+    if boundary is not None:
+        return boundary
+
+    # ColorKP = -1: refer to cube below
+    below_coord = (i, j, k - 1)
+    if below_coord in boundaries:
+        return list(boundaries[below_coord])
+
+    # Fallback to default
+    zdir = port_zdir_map.get(coord, default_zdir)
+    return _base_boundary(zdir)
+
+
 def _color_to_axis(color: int | bool) -> str:
     if color == 0 or color is False:
         return "X"
@@ -84,15 +143,17 @@ def _short_memory_pipe_block(axis: str, color: int) -> str:
     """Return short memory block type for pipe based on axis and color.
 
     Mapping:
-        I axis, color=0 -> ShortZMemoryBlock (InitZero + MeasureZ)
-        I axis, color=1 -> ShortXMemoryBlock (InitPlus + MeasureX)
-        J axis, color=0 -> ShortXMemoryBlock (InitPlus + MeasureX)
-        J axis, color=1 -> ShortZMemoryBlock (InitZero + MeasureZ)
+        I axis, color=0 -> ShortXMemoryBlock (X boundary)
+        I axis, color=1 -> ShortZMemoryBlock (Z boundary)
+        J axis, color=0 -> ShortZMemoryBlock (Z boundary)
+        J axis, color=1 -> ShortXMemoryBlock (X boundary)
     """
     if axis == "I":
-        return "ShortXMemoryBlock" if color == 1 else "ShortZMemoryBlock"
+        # ColorI: 0 -> X boundary, 1 -> Z boundary
+        return "ShortXMemoryBlock" if color == 0 else "ShortZMemoryBlock"
     # axis == "J"
-    return "ShortZMemoryBlock" if color == 1 else "ShortXMemoryBlock"
+    # ColorJ: 0 -> Z boundary, 1 -> X boundary
+    return "ShortZMemoryBlock" if color == 0 else "ShortXMemoryBlock"
 
 
 def _init_block(ch: str) -> str:
@@ -101,6 +162,43 @@ def _init_block(ch: str) -> str:
 
 def _meas_block(ch: str) -> str:
     return "MeasureXBlock" if ch.upper() == "X" else "MeasureZBlock"
+
+
+def _get_output_port_token(
+    stab_char: str,
+    boundary: list[str],
+    inverted: bool,
+) -> str | None:
+    """Determine logical observable token for output port MeasureBlock.
+
+    Parameters
+    ----------
+    stab_char : str
+        Stabilizer character ('X', 'Z', or '.').
+    boundary : list[str]
+        Boundary specification [T, B, L, R].
+    inverted : bool
+        Whether invert_ancilla_order is True.
+
+    Returns
+    -------
+    str | None
+        Token ('TB' or 'RL') or None if stab_char is '.'.
+    """
+    if stab_char.upper() not in {"X", "Z"}:
+        return None
+
+    # Determine boundary type (XXZZ or ZZXX based on T,B positions)
+    is_xxzz = boundary[0] == "X"  # T position
+
+    # Apply invert if needed
+    if inverted:
+        is_xxzz = not is_xxzz
+
+    if stab_char.upper() == "X":
+        return "TB" if is_xxzz else "RL"
+    # Z
+    return "RL" if is_xxzz else "TB"
 
 
 def _stab_char(stabilizer: str, idx: int) -> str:
@@ -172,13 +270,33 @@ def _build_cube_boundaries(
     pipes: Iterable[Pipe],
     port_zdir_map: dict[Coord3, str],
     default_zdir: str,
+    lasre: dict[str, Any],
+    invert_map: dict[Coord3, bool] | None = None,
 ) -> dict[Coord3, list[str]]:
-    """Create boundary spec per cube, applying O on faces touched by pipes."""
+    """Create boundary spec per cube, using ColorKP and applying O on pipe faces.
+
+    Parameters
+    ----------
+    invert_map : dict[Coord3, bool] | None
+        Mapping from cube coordinates to whether the boundary should be inverted
+        (used after Hadamard).
+    """
+    if invert_map is None:
+        invert_map = {}
+
     boundaries: dict[Coord3, list[str]] = {}
 
-    for coord in cubes:
-        zdir = port_zdir_map.get(coord, default_zdir)
-        boundaries[coord] = _base_boundary(zdir)
+    color_kp = lasre.get("ColorKP", [])
+    n_i, n_j, n_k = lasre["n_i"], lasre["n_j"], lasre["n_k"]
+
+    # Sort cubes by k to ensure lower cubes are processed first (for -1 reference)
+    sorted_cubes = sorted(cubes, key=operator.itemgetter(2, 1, 0))
+
+    for coord in sorted_cubes:
+        inverted = invert_map.get(coord, False)
+        boundaries[coord] = _resolve_cube_boundary(
+            coord, color_kp, n_i, n_j, n_k, boundaries, port_zdir_map, default_zdir, inverted
+        )
 
     # apply openings from pipes
     for axis, start, end, _ in pipes:
@@ -231,6 +349,20 @@ def _k_color_to_meas_block(color: int) -> str:
     return "MeasureZBlock" if color == 1 else "MeasureXBlock"
 
 
+def _k_color_to_meas_bulk_block(color: int) -> str:
+    """Return measure bulk block type based on K+ boundary color."""
+    # color=1 -> Z boundary -> MeasureBulkZBlock
+    # color=-1 -> X boundary -> MeasureBulkXBlock
+    return "MeasureBulkZBlock" if color == 1 else "MeasureBulkXBlock"
+
+
+def _k_color_to_short_memory_block(color: int) -> str:
+    """Return short memory block type based on K boundary color."""
+    # color=1 -> Z boundary -> ShortZMemoryBlock
+    # color=-1 -> X boundary -> ShortXMemoryBlock
+    return "ShortZMemoryBlock" if color == 1 else "ShortXMemoryBlock"
+
+
 def _has_k_minus_connection(i: int, j: int, k: int, exist_k: list[Any], n_i: int, n_j: int, n_k: int) -> bool:
     """Check if there's a K- connection (cube below connected via ExistK)."""
     if k == 0:
@@ -261,6 +393,216 @@ def _get_color_kp(i: int, j: int, k: int, color_kp: list[Any], n_i: int, n_j: in
     return int(color_kp[i][j][k])
 
 
+def _resolve_color_kp(
+    i: int, j: int, k: int,
+    color_kp: list[Any],
+    n_i: int, n_j: int, n_k: int,
+) -> int:
+    """Resolve ColorKP value, following -1 references to previous k."""
+    val = _get_color_kp(i, j, k, color_kp, n_i, n_j, n_k)
+    if val != -1:
+        return val
+    # -1 means "same as previous", look at k-1
+    if k > 0:
+        return _resolve_color_kp(i, j, k - 1, color_kp, n_i, n_j, n_k)
+    return 0  # default
+
+
+def _resolve_color_km(
+    i: int, j: int, k: int,
+    color_km: list[Any],
+    n_i: int, n_j: int, n_k: int,
+) -> int:
+    """Resolve ColorKM value, following -1 references to previous k."""
+    val = _get_color_km(i, j, k, color_km, n_i, n_j, n_k)
+    if val != -1:
+        return val
+    # -1 means "same as previous", look at k-1
+    if k > 0:
+        return _resolve_color_km(i, j, k - 1, color_km, n_i, n_j, n_k)
+    return 0  # default
+
+
+def _is_hadamard_cube(
+    i: int, j: int, k: int,
+    color_km: list[Any],
+    color_kp: list[Any],
+    n_i: int, n_j: int, n_k: int,
+) -> bool:
+    """Check if this cube has a Hadamard (resolved ColorKP[k] != resolved ColorKM[k-1]).
+
+    A Hadamard occurs when the K+ boundary color of the current cube differs
+    from the K- boundary color of the cube below.
+    """
+    if k == 0:
+        return False
+
+    # Resolved ColorKP of current cube
+    kp_val = _resolve_color_kp(i, j, k, color_kp, n_i, n_j, n_k)
+
+    # Resolved ColorKM of cube below (k-1)
+    km_below = _resolve_color_km(i, j, k - 1, color_km, n_i, n_j, n_k)
+
+    # Hadamard if different (0 and 1 are valid values to compare)
+    return kp_val != km_below
+
+
+def _compute_invert_ancilla_order(
+    cubes: set[Coord3],
+    color_km: list[Any],
+    color_kp: list[Any],
+    n_i: int, n_j: int, n_k: int,
+) -> tuple[set[Coord3], dict[Coord3, bool]]:
+    """Compute Hadamard cubes and invert_ancilla_order for all cubes.
+
+    Returns
+    -------
+    hadamard_cubes : set[Coord3]
+        Cubes where HadamardBlock should be placed.
+    invert_map : dict[Coord3, bool]
+        Whether each cube needs invert_ancilla_order=True.
+    """
+    hadamard_cubes: set[Coord3] = set()
+    invert_map: dict[Coord3, bool] = {}
+
+    # Sort cubes by k for each (i, j)
+    cubes_by_ij: dict[tuple[int, int], list[int]] = {}
+    for i, j, k in cubes:
+        cubes_by_ij.setdefault((i, j), []).append(k)
+
+    for (i, j), k_list in cubes_by_ij.items():
+        inverted = False
+        for k in sorted(k_list):
+            if _is_hadamard_cube(i, j, k, color_km, color_kp, n_i, n_j, n_k):
+                hadamard_cubes.add((i, j, k))
+                inverted = not inverted  # toggle
+            invert_map[i, j, k] = inverted
+
+    return hadamard_cubes, invert_map
+
+
+def _get_corr_value(lasre: dict[str, Any], corr_key: str, stab_idx: int, i: int, j: int, k: int) -> bool:
+    """Get correlation surface value at (stab_idx, i, j, k) for given key."""
+    corr = lasre.get(corr_key, [])
+    if not corr:
+        return False
+    n_s = lasre.get("n_s", len(corr))
+    n_i, n_j, n_k = lasre["n_i"], lasre["n_j"], lasre["n_k"]
+    if stab_idx >= n_s or i >= n_i or j >= n_j or k >= n_k:
+        return False
+    return bool(corr[stab_idx][i][j][k])
+
+
+def _get_corr_ki(lasre: dict[str, Any], stab_idx: int, i: int, j: int, k: int) -> bool:
+    """Get CorrKI value at (stab_idx, i, j, k)."""
+    return _get_corr_value(lasre, "CorrKI", stab_idx, i, j, k)
+
+
+def _get_corr_kj(lasre: dict[str, Any], stab_idx: int, i: int, j: int, k: int) -> bool:
+    """Get CorrKJ value at (stab_idx, i, j, k)."""
+    return _get_corr_value(lasre, "CorrKJ", stab_idx, i, j, k)
+
+
+def _get_corr_ij(lasre: dict[str, Any], stab_idx: int, i: int, j: int, k: int) -> bool:
+    """Get CorrIJ value at (stab_idx, i, j, k)."""
+    return _get_corr_value(lasre, "CorrIJ", stab_idx, i, j, k)
+
+
+def _get_corr_ik(lasre: dict[str, Any], stab_idx: int, i: int, j: int, k: int) -> bool:
+    """Get CorrIK value at (stab_idx, i, j, k)."""
+    return _get_corr_value(lasre, "CorrIK", stab_idx, i, j, k)
+
+
+def _get_corr_ji(lasre: dict[str, Any], stab_idx: int, i: int, j: int, k: int) -> bool:
+    """Get CorrJI value at (stab_idx, i, j, k)."""
+    return _get_corr_value(lasre, "CorrJI", stab_idx, i, j, k)
+
+
+def _get_corr_jk(lasre: dict[str, Any], stab_idx: int, i: int, j: int, k: int) -> bool:
+    """Get CorrJK value at (stab_idx, i, j, k)."""
+    return _get_corr_value(lasre, "CorrJK", stab_idx, i, j, k)
+
+
+def _get_pipe_logical_observables(
+    lasre: dict[str, Any],
+    stab_idx: int,
+    axis: str,
+    start: Coord3,
+    block: str,
+) -> list[dict[str, Any]] | None:
+    """Determine logical observables for a pipe from correlation surfaces.
+
+    Parameters
+    ----------
+    lasre : dict[str, Any]
+        Full lasre dictionary for correlation surface lookup.
+    stab_idx : int
+        Stabilizer index for correlation surface lookup.
+    axis : str
+        Pipe axis ("I" or "J").
+    start : Coord3
+        Pipe start coordinate (i, j, k).
+    block : str
+        Block type ("ShortXMemoryBlock" or "ShortZMemoryBlock").
+
+    Returns
+    -------
+    list[dict[str, Any]] | None
+        List of logical observable entries, or None if empty.
+    """
+    i, j, k = start
+    observables: list[dict[str, Any]] = []
+
+    if axis == "I":
+        # I-axis pipe: check CorrIJ and CorrIK
+        if _get_corr_ij(lasre, stab_idx, i, j, k):
+            if block == "ShortXMemoryBlock":
+                observables.append({"token": "X", "layer": 0, "sublayer": 2})
+            else:  # ShortZMemoryBlock
+                observables.append({"token": "Z", "layer": 0, "sublayer": 1})
+        if _get_corr_ik(lasre, stab_idx, i, j, k):
+            sublayer = 1 if block == "ShortXMemoryBlock" else 2
+            observables.append({"token": "RL", "layer": -1, "sublayer": sublayer})
+    else:  # axis == "J"
+        # J-axis pipe: check CorrJI and CorrJK
+        if _get_corr_ji(lasre, stab_idx, i, j, k):
+            if block == "ShortXMemoryBlock":
+                observables.append({"token": "X", "layer": 0, "sublayer": 2})
+            else:  # ShortZMemoryBlock
+                observables.append({"token": "Z", "layer": 0, "sublayer": 1})
+        if _get_corr_jk(lasre, stab_idx, i, j, k):
+            sublayer = 1 if block == "ShortXMemoryBlock" else 2
+            observables.append({"token": "TB", "layer": -1, "sublayer": sublayer})
+
+    return observables or None
+
+
+def _get_logical_observables(
+    lasre: dict[str, Any],
+    stab_idx: int,
+    k_pipe: Coord3,
+) -> str | list[str] | None:
+    """Determine logical observables for a measure block from correlation surfaces.
+
+    Returns
+    -------
+    str | list[str] | None
+        "TB" if CorrKI is 1, "RL" if CorrKJ is 1, ["TB", "RL"] if both,
+        or None if neither.
+    """
+    i, j, k = k_pipe
+    observables: list[str] = []
+    if _get_corr_ki(lasre, stab_idx, i, j, k):
+        observables.append("TB")
+    if _get_corr_kj(lasre, stab_idx, i, j, k):
+        observables.append("RL")
+    if len(observables) == 1:
+        return observables[0]
+    if len(observables) > 1:
+        return observables
+    return None
+
+
 def _assign_block_for_cube(
     coord: Coord3,
     exist_k: list[Any],
@@ -269,44 +611,61 @@ def _assign_block_for_cube(
     n_i: int,
     n_j: int,
     n_k: int,
-) -> tuple[str, Coord3 | None, str | None]:
+    hadamard_cubes: set[Coord3] | None = None,
+) -> tuple[str, Coord3 | None]:
     """Assign block type for a single non-port cube.
+
+    Parameters
+    ----------
+    hadamard_cubes : set[Coord3] | None
+        Set of cubes where HadamardBlock should be placed.
 
     Returns
     -------
     block : str
         Block type for this cube.
-    meas_coord : Coord3 | None
-        Coordinate for added measure cube (if any).
-    meas_block : str | None
-        Block type for added measure cube (if any).
+    k_pipe_coord : Coord3 | None
+        K-pipe coordinate for correlation surface lookup (if this has K+ boundary).
     """
     i, j, k = coord
+
+    # Check for Hadamard first
+    if hadamard_cubes and coord in hadamard_cubes:
+        return "HadamardBlock", None
+
     block = "MemoryBlock"
-    meas_coord: Coord3 | None = None
-    meas_block: str | None = None
+    k_pipe_coord: Coord3 | None = None
 
-    # Check K- connection for init
-    if not _has_k_minus_connection(i, j, k, exist_k, n_i, n_j, n_k):
-        # No K- connection -> needs Init block
-        # Use ColorKM at (i, j, k-1) to determine init type
+    # Check K- and K+ boundaries
+    has_k_minus_conn = _has_k_minus_connection(i, j, k, exist_k, n_i, n_j, n_k)
+    has_k_plus_conn = _has_k_plus_connection(i, j, k, exist_k, n_i, n_j, n_k)
+
+    # Get K- color (for init)
+    km_val = 0
+    if not has_k_minus_conn:
         km_val = _get_color_km(i, j, k - 1, color_km, n_i, n_j, n_k)
-        if km_val != 0:
-            block = _k_color_to_init_block(km_val)
-        else:
-            # Fallback: check ColorKM at current position
-            km_curr = _get_color_km(i, j, k, color_km, n_i, n_j, n_k)
-            if km_curr != 0:
-                block = _k_color_to_init_block(km_curr)
+        if km_val == 0:
+            km_val = _get_color_km(i, j, k, color_km, n_i, n_j, n_k)
 
-    # Check K+ connection for measure
-    if not _has_k_plus_connection(i, j, k, exist_k, n_i, n_j, n_k):
+    # Get K+ color (for measure)
+    kp_val = 0
+    if not has_k_plus_conn:
         kp_val = _get_color_kp(i, j, k, color_kp, n_i, n_j, n_k)
-        if kp_val != 0:
-            meas_coord = (i, j, k + 1)
-            meas_block = _k_color_to_meas_block(kp_val)
 
-    return block, meas_coord, meas_block
+    # Determine block type based on boundaries
+    if km_val != 0 and kp_val != 0:
+        # Both K- and K+ boundaries: use ShortMemoryBlock
+        block = _k_color_to_short_memory_block(kp_val)
+        k_pipe_coord = (i, j, k)
+    elif kp_val != 0:
+        # Only K+ boundary: use MeasureBulkBlock
+        block = _k_color_to_meas_bulk_block(kp_val)
+        k_pipe_coord = (i, j, k)
+    elif km_val != 0:
+        # Only K- boundary: use InitBlock
+        block = _k_color_to_init_block(km_val)
+
+    return block, k_pipe_coord
 
 
 def _assign_blocks_with_k_boundary(
@@ -315,8 +674,9 @@ def _assign_blocks_with_k_boundary(
     lasre_ports: Sequence[dict[str, Any]],
     lasre: dict[str, Any],
     stabilizer: str,
-) -> tuple[dict[Coord3, str], set[Coord3]]:
-    """Decide block type per cube and add measure cubes for K+ boundaries.
+    hadamard_cubes: set[Coord3] | None = None,
+) -> tuple[dict[Coord3, str], set[Coord3], dict[Coord3, Coord3]]:
+    """Decide block type per cube using MeasureBulk blocks for K+ boundaries.
 
     Parameters
     ----------
@@ -330,13 +690,17 @@ def _assign_blocks_with_k_boundary(
         Full lasre dictionary containing ColorKM, ColorKP, ExistK.
     stabilizer : str
         Stabilizer string for port-based init/measure assignment.
+    hadamard_cubes : set[Coord3] | None
+        Set of cubes where HadamardBlock should be placed.
 
     Returns
     -------
     blocks : dict[Coord3, str]
         Block type assignment for each cube.
     added_cubes : set[Coord3]
-        New cubes added at z+1 for K+ boundaries.
+        Always empty (no additional cubes needed with MeasureBulk blocks).
+    meas_to_k_pipe_map : dict[Coord3, Coord3]
+        Mapping from MeasureBulk/ShortMemory block coordinate to K-pipe coordinate.
     """
     color_km = lasre.get("ColorKM", [])
     color_kp = lasre.get("ColorKP", [])
@@ -344,20 +708,21 @@ def _assign_blocks_with_k_boundary(
     n_i, n_j, n_k = lasre["n_i"], lasre["n_j"], lasre["n_k"]
 
     port_cube_set = set(port_cubes)
-    added_cubes: set[Coord3] = set()
     blocks: dict[Coord3, str] = {}
+    meas_to_k_pipe_map: dict[Coord3, Coord3] = {}
 
-    # First pass: assign blocks to existing cubes
+    # Assign blocks to existing cubes
     for coord in cubes:
         if coord in port_cube_set:
             blocks[coord] = "MemoryBlock"
             continue
 
-        block, meas_coord, meas_block = _assign_block_for_cube(coord, exist_k, color_km, color_kp, n_i, n_j, n_k)
+        block, k_pipe_coord = _assign_block_for_cube(
+            coord, exist_k, color_km, color_kp, n_i, n_j, n_k, hadamard_cubes
+        )
         blocks[coord] = block
-        if meas_coord is not None and meas_block is not None:
-            added_cubes.add(meas_coord)
-            blocks[meas_coord] = meas_block
+        if k_pipe_coord is not None:
+            meas_to_k_pipe_map[coord] = k_pipe_coord
 
     # Override with port-based assignments (these take precedence)
     for idx, (port, coord) in enumerate(zip(lasre_ports, port_cubes, strict=True)):
@@ -367,7 +732,7 @@ def _assign_blocks_with_k_boundary(
         else:  # output / top
             blocks[coord] = _meas_block(ch)
 
-    return blocks, added_cubes
+    return blocks, set(), meas_to_k_pipe_map
 
 
 def _check_no_y_cubes(lasre: dict[str, Any]) -> None:
@@ -380,6 +745,151 @@ def _check_no_y_cubes(lasre: dict[str, Any]) -> None:
                 if val:
                     msg = "Y cubes are not supported yet. Aborting import."
                     raise LasImportError(msg)
+
+
+def _build_toplevel_logical_observables(
+    meas_to_k_pipe_map: dict[Coord3, Coord3],
+    pipes: list[Pipe],
+    lasre: dict[str, Any],
+    stab_idx: int,
+    output_port_cubes: list[Coord3] | None = None,
+) -> list[dict[str, Any]]:
+    """Build top-level logical_observables section for YAML output.
+
+    Collects all cubes and pipes that have correlation surface values set,
+    and groups them into a single logical_observables entry.
+
+    Parameters
+    ----------
+    meas_to_k_pipe_map : dict[Coord3, Coord3]
+        Mapping from measure block coordinate to original K-pipe coordinate.
+    pipes : list[Pipe]
+        List of pipes (axis, start, end, color).
+    lasre : dict[str, Any]
+        Full lasre dictionary for correlation surface lookup.
+    stab_idx : int
+        Stabilizer index for correlation surface lookup.
+    output_port_cubes : list[Coord3] | None
+        List of output port cube coordinates to include.
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        Top-level logical_observables entries for YAML output.
+    """
+    cube_coords: list[list[int]] = []
+    pipe_coords: list[list[list[int]]] = []
+
+    # Collect cube coordinates with correlation surface values
+    for meas_coord, k_pipe in meas_to_k_pipe_map.items():
+        i, j, k = k_pipe
+        if _get_corr_ki(lasre, stab_idx, i, j, k) or _get_corr_kj(lasre, stab_idx, i, j, k):
+            cube_coords.append(list(meas_coord))
+
+    # Add output port cubes
+    if output_port_cubes:
+        cube_coords.extend(list(coord) for coord in output_port_cubes)
+
+    # Collect pipe coordinates with correlation surface values
+    for axis, start, end, _color in pipes:
+        i, j, k = start
+        has_corr = False
+        if axis == "I":
+            has_corr = _get_corr_ij(lasre, stab_idx, i, j, k) or _get_corr_ik(lasre, stab_idx, i, j, k)
+        else:  # axis == "J"
+            has_corr = _get_corr_ji(lasre, stab_idx, i, j, k) or _get_corr_jk(lasre, stab_idx, i, j, k)
+        if has_corr:
+            pipe_coords.append([list(start), list(end)])
+
+    if not cube_coords and not pipe_coords:
+        return []
+
+    entry: dict[str, Any] = {}
+    if cube_coords:
+        entry["cube"] = cube_coords
+    if pipe_coords:
+        entry["pipe"] = pipe_coords
+
+    return [entry]
+
+
+def _build_cube_entries(
+    all_cubes: set[Coord3],
+    blocks: dict[Coord3, str],
+    all_boundaries: dict[Coord3, list[str]],
+    meas_to_k_pipe_map: dict[Coord3, Coord3],
+    lasre: dict[str, Any],
+    stab_idx: int,
+    invert_map: dict[Coord3, bool] | None = None,
+    output_port_info: dict[Coord3, str] | None = None,
+) -> list[dict[str, Any]]:
+    """Build cube entry list for YAML output.
+
+    Parameters
+    ----------
+    all_cubes : set[Coord3]
+        All cube coordinates.
+    blocks : dict[Coord3, str]
+        Block type assignment for each cube.
+    all_boundaries : dict[Coord3, list[str]]
+        Boundary specification for each cube.
+    meas_to_k_pipe_map : dict[Coord3, Coord3]
+        Mapping from measure block coordinate to original K-pipe coordinate.
+    lasre : dict[str, Any]
+        Full lasre dictionary for correlation surface lookup.
+    stab_idx : int
+        Stabilizer index for correlation surface lookup.
+    invert_map : dict[Coord3, bool] | None
+        Mapping from cube coordinates to whether invert_ancilla_order=True.
+    output_port_info : dict[Coord3, str] | None
+        Mapping from output port cube coordinates to stabilizer character.
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        Cube entries for YAML output.
+    """
+    if invert_map is None:
+        invert_map = {}
+    if output_port_info is None:
+        output_port_info = {}
+
+    cube_entries: list[dict[str, Any]] = []
+    for coord in sorted(all_cubes, key=operator.itemgetter(2, 1, 0)):
+        entry: dict[str, Any] = {
+            "position": list(coord),
+            "block": blocks[coord],
+            "boundary": "".join(all_boundaries[coord]),
+        }
+
+        # Add invert_ancilla_order if True
+        if invert_map.get(coord, False):
+            entry["invert_ancilla_order"] = True
+
+        # Add logical_observables for blocks with K+ boundary based on correlation surfaces
+        # This includes MeasureBulk blocks and ShortMemory blocks
+        measure_blocks = {
+            "MeasureBulkXBlock",
+            "MeasureBulkZBlock",
+            "ShortXMemoryBlock",
+            "ShortZMemoryBlock",
+        }
+        if blocks[coord] in measure_blocks and coord in meas_to_k_pipe_map:
+            k_pipe = meas_to_k_pipe_map[coord]
+            observables = _get_logical_observables(lasre, stab_idx, k_pipe)
+            if observables is not None:
+                entry["logical_observables"] = observables
+
+        # Add logical_observables for output port MeasureBlocks
+        if coord in output_port_info:
+            stab_char = output_port_info[coord]
+            inverted = invert_map.get(coord, False)
+            token = _get_output_port_token(stab_char, all_boundaries[coord], inverted)
+            if token is not None:
+                entry["logical_observables"] = token
+
+        cube_entries.append(entry)
+    return cube_entries
 
 
 # ---------------------------------------------------------------------------
@@ -435,12 +945,23 @@ def convert_lasre_to_yamls(
     port_zdir_map = _cube_orientation_map(spec_ports, port_cubes)
     default_zdir = next(iter(port_zdir_map.values()), "J")
 
-    boundaries = _build_cube_boundaries(cubes, pipes, port_zdir_map, default_zdir)
+    # Compute Hadamard cubes and invert_ancilla_order for all cubes
+    color_km = lasre.get("ColorKM", [])
+    color_kp = lasre.get("ColorKP", [])
+    n_i, n_j, n_k = lasre["n_i"], lasre["n_j"], lasre["n_k"]
+    hadamard_cubes, invert_map = _compute_invert_ancilla_order(
+        cubes, color_km, color_kp, n_i, n_j, n_k
+    )
+
+    # Build boundaries with invert_map
+    boundaries = _build_cube_boundaries(cubes, pipes, port_zdir_map, default_zdir, lasre, invert_map)
 
     yaml_results: list[tuple[str, str]] = []
 
     for stab_idx, stab in enumerate(stabilizers):
-        blocks, added_cubes = _assign_blocks_with_k_boundary(cubes, port_cubes, lasre_ports, lasre, stab)
+        blocks, added_cubes, meas_to_k_pipe_map = _assign_blocks_with_k_boundary(
+            cubes, port_cubes, lasre_ports, lasre, stab, hadamard_cubes
+        )
 
         # Combine original cubes with added measure cubes
         all_cubes = cubes | added_cubes
@@ -451,25 +972,43 @@ def convert_lasre_to_yamls(
             if coord not in all_boundaries:
                 all_boundaries[coord] = _base_boundary(default_zdir)
 
-        cube_entries = [
-            {
-                "position": list(coord),
-                "block": blocks[coord],
-                "boundary": "".join(all_boundaries[coord]),
-            }
-            for coord in sorted(all_cubes, key=operator.itemgetter(2, 1, 0))
-        ]
+        # Collect output port info for this stabilizer
+        output_port_info: dict[Coord3, str] = {}
+        output_port_cubes: list[Coord3] = []
+        for idx, (port, coord) in enumerate(zip(lasre_ports, port_cubes, strict=True)):
+            ch = _stab_char(stab, idx)
+            if port.get("e") != "-" and ch.upper() in {"X", "Z"}:
+                output_port_info[coord] = ch
+                output_port_cubes.append(coord)
+
+        cube_entries = _build_cube_entries(
+            all_cubes, blocks, all_boundaries, meas_to_k_pipe_map, lasre, stab_idx, invert_map,
+            output_port_info,
+        )
 
         # Generate single-layer pipe structure using short memory blocks
         pipe_entries: list[dict[str, Any]] = []
         for axis, start, end, color in pipes:
             boundary = _pipe_boundary(axis, color)
-            pipe_entries.append({
+            block = _short_memory_pipe_block(axis, color)
+            entry: dict[str, Any] = {
                 "start": list(start),
                 "end": list(end),
-                "block": _short_memory_pipe_block(axis, color),
+                "block": block,
                 "boundary": boundary,
-            })
+            }
+
+            # Add logical_observables based on correlation surfaces
+            observables = _get_pipe_logical_observables(lasre, stab_idx, axis, start, block)
+            if observables is not None:
+                entry["logical_observables"] = observables
+
+            pipe_entries.append(entry)
+
+        # Build top-level logical_observables section
+        toplevel_observables = _build_toplevel_logical_observables(
+            meas_to_k_pipe_map, pipes, lasre, stab_idx, output_port_cubes
+        )
 
         desc_base = description or name_prefix
         canvas_dict: dict[str, Any] = {
@@ -479,6 +1018,8 @@ def convert_lasre_to_yamls(
             "cube": cube_entries,
             "pipe": pipe_entries,
         }
+        if toplevel_observables:
+            canvas_dict["logical_observables"] = toplevel_observables
 
         yaml_text = yaml.safe_dump(
             canvas_dict,

--- a/lspattern/patch_layout/blocks/measure_bulk_x_block.yml
+++ b/lspattern/patch_layout/blocks/measure_bulk_x_block.yml
@@ -1,0 +1,11 @@
+name: MeasureBulkXBlock
+description: |
+  This block represents a X measure bulk block.
+  Components: MemoryUnit, MeasureXUnit
+  Used by:
+
+layers: # list of layers in this block
+  - type: MemoryUnit
+    num_layers_from_distance: rest
+  - type: MeasureXUnit
+    num_layers: 1

--- a/lspattern/patch_layout/blocks/measure_bulk_z_block.yml
+++ b/lspattern/patch_layout/blocks/measure_bulk_z_block.yml
@@ -1,0 +1,11 @@
+name: MeasureBulkZBlock
+description: |
+  This block represents a Z measure bulk block.
+  Components: MemoryUnit, MeasureZPartialUnit
+  Used by:
+
+layers: # list of layers in this block
+  - type: MemoryUnit
+    num_layers_from_distance: rest
+  - type: MeasureZPartialUnit
+    num_layers: 1

--- a/tests/test_las_hadamard.py
+++ b/tests/test_las_hadamard.py
@@ -1,0 +1,179 @@
+"""Unit tests for Hadamard detection and invert_ancilla_order in las.py."""
+
+from __future__ import annotations
+
+from lspattern.importer.las import (
+    _color_kp_to_boundary,
+    _compute_invert_ancilla_order,
+    _is_hadamard_cube,
+    _resolve_color_km,
+    _resolve_color_kp,
+)
+
+
+class TestResolveColorKp:
+    """Test _resolve_color_kp function."""
+
+    def test_returns_direct_value_when_not_minus_one(self) -> None:
+        """ColorKP = 0 or 1 should return directly."""
+        color_kp = [[[0, 1, 0]]]
+        assert _resolve_color_kp(0, 0, 0, color_kp, 1, 1, 3) == 0
+        assert _resolve_color_kp(0, 0, 1, color_kp, 1, 1, 3) == 1
+        assert _resolve_color_kp(0, 0, 2, color_kp, 1, 1, 3) == 0
+
+    def test_follows_minus_one_to_previous_k(self) -> None:
+        """ColorKP = -1 should refer to k-1."""
+        color_kp = [[[1, -1, -1]]]
+        assert _resolve_color_kp(0, 0, 0, color_kp, 1, 1, 3) == 1
+        assert _resolve_color_kp(0, 0, 1, color_kp, 1, 1, 3) == 1  # follows k-1
+        assert _resolve_color_kp(0, 0, 2, color_kp, 1, 1, 3) == 1  # follows k-1 twice
+
+    def test_returns_zero_when_all_minus_one_from_k_zero(self) -> None:
+        """When chaining -1 reaches k=0 with -1, return 0 as default.
+
+        -1 at k=0 can't reference k-1, so it returns 0 (default).
+        """
+        color_kp = [[[-1, -1]]]
+        # _get_color_kp returns -1, but _resolve checks != -1: False
+        # Then k > 0 check: k=0 is not > 0, so return 0 (default)
+        assert _resolve_color_kp(0, 0, 0, color_kp, 1, 1, 2) == 0
+        assert _resolve_color_kp(0, 0, 1, color_kp, 1, 1, 2) == 0  # follows to k=0 which is 0
+
+
+class TestResolveColorKm:
+    """Test _resolve_color_km function."""
+
+    def test_returns_direct_value_when_not_minus_one(self) -> None:
+        """ColorKM = 0 or 1 should return directly."""
+        color_km = [[[0, 1, 0]]]
+        assert _resolve_color_km(0, 0, 0, color_km, 1, 1, 3) == 0
+        assert _resolve_color_km(0, 0, 1, color_km, 1, 1, 3) == 1
+        assert _resolve_color_km(0, 0, 2, color_km, 1, 1, 3) == 0
+
+    def test_follows_minus_one_to_previous_k(self) -> None:
+        """ColorKM = -1 should refer to k-1."""
+        color_km = [[[1, -1, -1]]]
+        assert _resolve_color_km(0, 0, 0, color_km, 1, 1, 3) == 1
+        assert _resolve_color_km(0, 0, 1, color_km, 1, 1, 3) == 1  # follows k-1
+        assert _resolve_color_km(0, 0, 2, color_km, 1, 1, 3) == 1  # follows k-1 twice
+
+
+class TestIsHadamardCube:
+    """Test _is_hadamard_cube function."""
+
+    def test_k_zero_never_hadamard(self) -> None:
+        """k=0 cubes can never be Hadamard."""
+        color_km = [[[0]]]
+        color_kp = [[[1]]]
+        assert _is_hadamard_cube(0, 0, 0, color_km, color_kp, 1, 1, 1) is False
+
+    def test_hadamard_when_kp_differs_from_km_below(self) -> None:
+        """Hadamard when ColorKP[k] != ColorKM[k-1]."""
+        # ColorKM[0] = 0, ColorKP[1] = 1 -> different -> Hadamard
+        color_km = [[[0, 0]]]
+        color_kp = [[[0, 1]]]
+        assert _is_hadamard_cube(0, 0, 1, color_km, color_kp, 1, 1, 2) is True
+
+    def test_no_hadamard_when_kp_equals_km_below(self) -> None:
+        """No Hadamard when ColorKP[k] == ColorKM[k-1]."""
+        # ColorKM[0] = 0, ColorKP[1] = 0 -> same -> no Hadamard
+        color_km = [[[0, 0]]]
+        color_kp = [[[0, 0]]]
+        assert _is_hadamard_cube(0, 0, 1, color_km, color_kp, 1, 1, 2) is False
+
+    def test_hadamard_with_resolved_minus_one(self) -> None:
+        """Hadamard detection works with resolved -1 values."""
+        # ColorKM[0] = 0, ColorKM[1] = -1 (resolves to 0)
+        # ColorKP[1] = 1, ColorKP[2] = -1 (resolves to 1)
+        # At k=2: ColorKP[2] resolved = 1, ColorKM[1] resolved = 0 -> different -> Hadamard
+        color_km = [[[0, -1, 0]]]
+        color_kp = [[[0, 1, -1]]]
+        assert _is_hadamard_cube(0, 0, 2, color_km, color_kp, 1, 1, 3) is True
+
+
+class TestComputeInvertAncillaOrder:
+    """Test _compute_invert_ancilla_order function."""
+
+    def test_no_hadamard_all_false(self) -> None:
+        """When no Hadamard, all cubes have invert=False."""
+        cubes = {(0, 0, 0), (0, 0, 1), (0, 0, 2)}
+        # ColorKP[k] == ColorKM[k-1] for all k -> no Hadamard
+        color_km = [[[0, 0, 0]]]
+        color_kp = [[[0, 0, 0]]]
+        hadamard_cubes, invert_map = _compute_invert_ancilla_order(
+            cubes, color_km, color_kp, 1, 1, 3
+        )
+        assert hadamard_cubes == set()
+        assert invert_map[0, 0, 0] is False
+        assert invert_map[0, 0, 1] is False
+        assert invert_map[0, 0, 2] is False
+
+    def test_single_hadamard_inverts_after(self) -> None:
+        """Single Hadamard at k=1 inverts cubes k>=1."""
+        cubes = {(0, 0, 0), (0, 0, 1), (0, 0, 2)}
+        # ColorKM[0] = 0, ColorKP[1] = 1 -> Hadamard at k=1
+        # ColorKM[1] = 1, ColorKP[2] = 1 -> no Hadamard at k=2
+        color_km = [[[0, 1, 1]]]
+        color_kp = [[[0, 1, 1]]]
+        hadamard_cubes, invert_map = _compute_invert_ancilla_order(
+            cubes, color_km, color_kp, 1, 1, 3
+        )
+        assert hadamard_cubes == {(0, 0, 1)}
+        assert invert_map[0, 0, 0] is False
+        assert invert_map[0, 0, 1] is True  # Hadamard cube, inverted after
+        assert invert_map[0, 0, 2] is True  # after Hadamard, still inverted
+
+    def test_double_hadamard_toggles_back(self) -> None:
+        """Two Hadamards toggle invert back to False."""
+        cubes = {(0, 0, 0), (0, 0, 1), (0, 0, 2), (0, 0, 3)}
+        # ColorKM[0] = 0, ColorKP[1] = 1 -> Hadamard at k=1
+        # ColorKM[1] = 1, ColorKP[2] = 1 -> no Hadamard at k=2
+        # ColorKM[2] = 1, ColorKP[3] = 0 -> Hadamard at k=3
+        color_km = [[[0, 1, 1, 0]]]
+        color_kp = [[[0, 1, 1, 0]]]
+        hadamard_cubes, invert_map = _compute_invert_ancilla_order(
+            cubes, color_km, color_kp, 1, 1, 4
+        )
+        assert hadamard_cubes == {(0, 0, 1), (0, 0, 3)}
+        assert invert_map[0, 0, 0] is False
+        assert invert_map[0, 0, 1] is True  # first Hadamard
+        assert invert_map[0, 0, 2] is True  # between Hadamards
+        assert invert_map[0, 0, 3] is False  # second Hadamard toggles back
+
+    def test_multiple_ij_columns_independent(self) -> None:
+        """Different (i,j) columns have independent invert tracking."""
+        cubes = {(0, 0, 0), (0, 0, 1), (1, 0, 0), (1, 0, 1)}
+        # ColorKM[0][0][0] = 0, ColorKP[0][0][1] = 1 -> Hadamard at (0,0,1)
+        # ColorKM[1][0][0] = 0, ColorKP[1][0][1] = 0 -> no Hadamard at (1,0,1)
+        color_km = [[[0, 1], [0, 0]], [[0, 0], [0, 0]]]
+        color_kp = [[[0, 1], [0, 0]], [[0, 0], [0, 0]]]
+        hadamard_cubes, invert_map = _compute_invert_ancilla_order(
+            cubes, color_km, color_kp, 2, 2, 2
+        )
+        assert (0, 0, 1) in hadamard_cubes
+        assert (1, 0, 1) not in hadamard_cubes
+        assert invert_map[0, 0, 0] is False
+        assert invert_map[0, 0, 1] is True
+        assert invert_map[1, 0, 0] is False
+        assert invert_map[1, 0, 1] is False
+
+
+class TestColorKpToBoundary:
+    """Test _color_kp_to_boundary with inverted parameter."""
+
+    def test_normal_mapping(self) -> None:
+        """Normal mapping: 0->ZZXX, 1->XXZZ."""
+        assert _color_kp_to_boundary(0) == list("ZZXX")
+        assert _color_kp_to_boundary(1) == list("XXZZ")
+        assert _color_kp_to_boundary(-1) is None
+
+    def test_inverted_mapping(self) -> None:
+        """Inverted mapping: 0->XXZZ, 1->ZZXX."""
+        assert _color_kp_to_boundary(0, inverted=True) == list("XXZZ")
+        assert _color_kp_to_boundary(1, inverted=True) == list("ZZXX")
+        assert _color_kp_to_boundary(-1, inverted=True) is None
+
+    def test_explicit_false_same_as_default(self) -> None:
+        """Explicit inverted=False is same as default."""
+        assert _color_kp_to_boundary(0, inverted=False) == list("ZZXX")
+        assert _color_kp_to_boundary(1, inverted=False) == list("XXZZ")


### PR DESCRIPTION
## Summary
- Simplify pipe generation to single-layer Short Memory Blocks (`ShortXMemoryBlock`/`ShortZMemoryBlock`), eliminating the two-layer pipe structure and stacking conflict checks
- Add bulk measure blocks (`MeasureBulkXBlock`, `MeasureBulkZBlock`) with corresponding YAML definitions
- Update LAS importer to support Hadamard blocks, `invert_ancilla_order`, `logical_observables`, and improved boundary handling
- Update CNOT spec demo YAML files to reflect new block types and boundary configurations
- Add Hadamard block test suite (`test_las_hadamard.py`)

## Test plan
- [ ] `pytest tests/test_las_hadamard.py` passes
- [ ] Existing tests remain passing
- [ ] CNOT spec YAMLs correctly load and compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)