### PR TITLE
Add custom noise model support to compile_canvas_to_stim

### DIFF
--- a/tests/test_custom_noise_models.py
+++ b/tests/test_custom_noise_models.py
@@ -1,0 +1,43 @@
+"""Tests for custom graphqomb noise model support."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from graphqomb.noise_model import NoiseModel, PrepareEvent, RawStimOp
+
+from lspattern.canvas_loader import load_canvas
+from lspattern.compiler import compile_canvas_to_stim
+
+_MEMORY_CANVAS_PATH = Path(__file__).resolve().parent.parent / "examples" / "memory_canvas.yml"
+
+
+class _PrepareXErrorNoise(NoiseModel):  # type: ignore[misc]
+    def __init__(self, p: float) -> None:
+        self._p = p
+
+    def on_prepare(self, event: PrepareEvent) -> tuple[RawStimOp]:
+        return (RawStimOp(f"X_ERROR({self._p}) {event.node.id}"),)
+
+
+def test_compile_canvas_to_stim_accepts_custom_noise_models() -> None:
+    canvas, _ = load_canvas(_MEMORY_CANVAS_PATH, code_distance=3)
+
+    circuit_str = compile_canvas_to_stim(
+        canvas,
+        noise_models=[_PrepareXErrorNoise(0.123)],
+    )
+
+    assert "X_ERROR(0.123)" in circuit_str
+
+
+def test_compile_canvas_to_stim_rejects_mixed_legacy_and_noise_models() -> None:
+    canvas, _ = load_canvas(_MEMORY_CANVAS_PATH, code_distance=3)
+
+    with pytest.raises(ValueError, match="cannot be used together with noise_models"):
+        compile_canvas_to_stim(
+            canvas,
+            p_before_meas_flip=0.001,
+            noise_models=[_PrepareXErrorNoise(0.123)],
+        )


### PR DESCRIPTION
## Summary
- Extract `compile_canvas_to_pattern` as a reusable function returning `(Pattern, BaseGraphState, node_map)`
- Add `noise_models` parameter to `compile_canvas_to_stim` for injecting custom `graphqomb.NoiseModel` instances
- Make legacy parameters (`p_depol_after_clifford`, `p_before_meas_flip`) optional

## Test plan
- [x] Added tests for custom noise model injection
- [x] Added test to verify legacy and noise_models params cannot be mixed
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)