### PR TITLE
Update graphqomb compatibility

### DIFF
--- a/lspattern/compiler.py
+++ b/lspattern/compiler.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from graphlib import TopologicalSorter
 from typing import TYPE_CHECKING
 
 from graphqomb.common import AxisMeasBasis, Sign
 from graphqomb.graphstate import GraphState
+from graphqomb.noise_model import DepolarizingNoiseModel, MeasurementFlipNoiseModel
 from graphqomb.qompiler import qompile
 from graphqomb.scheduler import Scheduler
 from graphqomb.stim_compiler import stim_compile
@@ -76,6 +78,29 @@ def _collect_logical_observable_nodes(  # noqa: C901
     return nodes
 
 
+def _delay_measurements_for_flow(scheduler: Scheduler) -> None:
+    """Delay equal-time measurements until the manual schedule satisfies flow causality."""
+    predecessors: dict[int, set[int]] = {node: set() for node in scheduler.measure_time}
+    for source, successors in scheduler.dag.items():
+        if source not in scheduler.measure_time:
+            continue
+        for successor in successors:
+            if successor in scheduler.measure_time:
+                predecessors[successor].add(source)
+
+    for node in TopologicalSorter(predecessors).static_order():
+        measure_time = scheduler.measure_time[node]
+        if measure_time is None:
+            continue
+
+        min_measure_time = measure_time
+        for predecessor in predecessors[node]:
+            predecessor_time = scheduler.measure_time[predecessor]
+            if predecessor_time is not None and predecessor_time >= min_measure_time:
+                min_measure_time = predecessor_time + 1
+        scheduler.measure_time[node] = min_measure_time
+
+
 def compile_canvas_to_stim(
     canvas: Canvas,
     p_depol_after_clifford: float,
@@ -94,6 +119,8 @@ def compile_canvas_to_stim(
     prep_time, meas_time, entangle_time = canvas.scheduler.to_node_schedule(node_map)
     scheduler = Scheduler(graph, flow)
     scheduler.manual_schedule(prep_time, meas_time, entangle_time)
+    _delay_measurements_for_flow(scheduler)
+    scheduler.validate_schedule()
 
     # construct detectors
     coord2detectors = construct_detector(canvas.parity_accumulator)
@@ -102,7 +129,6 @@ def compile_canvas_to_stim(
         det_nodes = {node_map[coord] for coord in det_coords if coord in node_map}
         if det_nodes:
             detectors.append(frozenset(det_nodes))
-    pattern = qompile(graph, flow, parity_check_group=detectors, scheduler=scheduler)
 
     # extract logical observables from canvas
     logical_observables_nodes: dict[int, set[int]] = {}
@@ -110,10 +136,19 @@ def compile_canvas_to_stim(
         nodes = _collect_logical_observable_nodes(canvas, composite_logical_obs)
         logical_observables_nodes[key] = {node_map[coord] for coord in nodes}
 
+    pattern = qompile(
+        graph,
+        flow,
+        parity_check_group=detectors,
+        logical_observables=logical_observables_nodes,
+        scheduler=scheduler,
+    )
+
     result: str = stim_compile(
         pattern,
-        logical_observables_nodes,
-        p_depol_after_clifford=p_depol_after_clifford,
-        p_before_meas_flip=p_before_meas_flip,
+        noise_models=[
+            DepolarizingNoiseModel(p1=p_depol_after_clifford),
+            MeasurementFlipNoiseModel(p=p_before_meas_flip),
+        ],
     )
     return result

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-ruff
+ruff==0.15.13
 mypy
 pyright
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ ortools>=9,<10
 typing_extensions>=4.0
 nbformat>=4.20
 plotly>=6
-graphqomb>=0.1.1
+graphqomb>=0.3.1
 pydantic>=2.0.0
 pyyaml>=6

--- a/tests/test_graph_block_yaml.py
+++ b/tests/test_graph_block_yaml.py
@@ -3,8 +3,12 @@
 from pathlib import Path
 from textwrap import dedent
 
+import pytest
+from graphqomb.graphstate import GraphState
+from graphqomb.scheduler import Scheduler
+
 from lspattern.canvas_loader import load_canvas
-from lspattern.compiler import compile_canvas_to_stim
+from lspattern.compiler import _delay_measurements_for_flow, compile_canvas_to_stim
 from lspattern.mytype import Coord2D, Coord3D
 
 
@@ -14,6 +18,34 @@ def _write_yaml(path: Path, content: str) -> None:
 
 def _write_json(path: Path, content: str) -> None:
     path.write_text(dedent(content).strip() + "\n", encoding="utf-8")
+
+
+def test_delay_measurements_for_flow_splits_equal_time_dependencies() -> None:
+    graph, node_map = GraphState.from_graph(
+        nodes=["input", "middle", "output"],
+        edges=[("input", "middle"), ("middle", "output")],
+        inputs=["input"],
+        outputs=["output"],
+    )
+    input_node = node_map["input"]
+    middle_node = node_map["middle"]
+    output_node = node_map["output"]
+
+    flow = {input_node: {middle_node}, middle_node: {output_node}}
+    scheduler = Scheduler(graph, flow)
+    scheduler.manual_schedule(
+        prepare_time={middle_node: 0, output_node: 0},
+        measure_time={input_node: 1, middle_node: 1},
+    )
+
+    with pytest.raises(ValueError, match="DAG violation"):
+        scheduler.validate_schedule()
+
+    _delay_measurements_for_flow(scheduler)
+
+    assert scheduler.measure_time[input_node] == 1
+    assert scheduler.measure_time[middle_node] == 2
+    scheduler.validate_schedule()
 
 
 def test_load_canvas_with_graph_block(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Update the graphqomb dependency floor to 0.3.1
- Adapt `compile_canvas_to_stim()` to graphqomb's noise model and logical observable APIs
- Delay same-time flow-dependent measurements before scheduler validation
- Pin the CI ruff version so `ruff-action` uses the locally validated version instead of latest
- Add a regression test for scheduler causality adjustment

## Root Cause
Graphqomb 0.3.x removed legacy `stim_compile()` noise arguments, moved logical observable handling into `qompile()`, and now validates manually provided schedulers before pattern generation. Existing ls-pattern schedules could contain flow-dependent measurements in the same time slice, which graphqomb now rejects.

The ruff workflow also passed `requirements-dev.txt` as a version source, but the file did not contain a parseable ruff version. GitHub Actions therefore installed latest ruff, which introduced failures unrelated to this change.

## Validation
- `uv run --no-sync pytest`
- `uv run --no-sync mypy`
- `uv run --no-sync pyright`
- `uv run --no-sync ruff check ./lspattern ./tests ./examples`
- `uv run --no-sync ruff format --check --diff`
- `PYTHONPATH=/home/masa10/git-repos/utftbmqc/graphqomb .venv/bin/python -m pytest -q`