### PR TITLE
Restore cube_at_offset layout helper

### DIFF
--- a/lspattern/layout/rotated_surface_code.py
+++ b/lspattern/layout/rotated_surface_code.py
@@ -156,7 +156,33 @@ class RotatedSurfaceCodeLayout(TopologicalCodeLayoutBuilder):
         """
         offset = self.cube_offset(code_distance, global_pos)
         bounds = self.cube_bounds(code_distance, offset)
+        return self._cube_with_bounds(bounds, boundary, corner_decisions=corner_decisions)
 
+    def cube_at_offset(
+        self,
+        code_distance: int,
+        offset: Coord2D,
+        boundary: Mapping[BoundarySide, EdgeSpecValue],
+        *,
+        corner_decisions: Mapping[CornerPosition, CornerAncillaDecision] | None = None,
+    ) -> PatchCoordinates:
+        """Build complete cube layout coordinates at a physical 2D offset."""
+        bounds = self.cube_bounds(code_distance, Coord2D(0, 0))
+        coords = self._cube_with_bounds(bounds, boundary, corner_decisions=corner_decisions)
+        return PatchCoordinates(
+            data=frozenset(Coord2D(coord.x + offset.x, coord.y + offset.y) for coord in coords.data),
+            ancilla_x=frozenset(Coord2D(coord.x + offset.x, coord.y + offset.y) for coord in coords.ancilla_x),
+            ancilla_z=frozenset(Coord2D(coord.x + offset.x, coord.y + offset.y) for coord in coords.ancilla_z),
+        )
+
+    def _cube_with_bounds(
+        self,
+        bounds: PatchBounds,
+        boundary: Mapping[BoundarySide, EdgeSpecValue],
+        *,
+        corner_decisions: Mapping[CornerPosition, CornerAncillaDecision] | None = None,
+    ) -> PatchCoordinates:
+        """Build complete cube layout coordinates inside explicit bounds."""
         # Generate components
         bulk = generate_checkerboard_coords(bounds)
         corner_data_remove = self._get_corner_data_to_remove(bounds, boundary)
@@ -1361,6 +1387,17 @@ class RotatedSurfaceCodeLayoutBuilder:
             Complete coordinate sets for the cube.
         """
         return _default_layout.cube(code_distance, global_pos, boundary, corner_decisions=corner_decisions)
+
+    @staticmethod
+    def cube_at_offset(
+        code_distance: int,
+        offset: Coord2D,
+        boundary: Mapping[BoundarySide, EdgeSpecValue],
+        *,
+        corner_decisions: Mapping[CornerPosition, CornerAncillaDecision] | None = None,
+    ) -> PatchCoordinates:
+        """Build complete cube layout coordinates at a physical 2D offset."""
+        return _default_layout.cube_at_offset(code_distance, offset, boundary, corner_decisions=corner_decisions)
 
     @staticmethod
     def pipe(

--- a/lspattern/plot_error_rate.py
+++ b/lspattern/plot_error_rate.py
@@ -8,7 +8,7 @@ customizable titles.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -25,6 +25,37 @@ if TYPE_CHECKING:
 
     from matplotlib.axes import Axes
     from matplotlib.figure import Figure
+
+type LegendLocation = (
+    Literal[
+        "best",
+        "upper right",
+        "upper left",
+        "lower left",
+        "lower right",
+        "right",
+        "center left",
+        "center right",
+        "lower center",
+        "upper center",
+        "center",
+        "outside upper left",
+        "outside upper center",
+        "outside upper right",
+        "outside right upper",
+        "outside right center",
+        "outside right lower",
+        "outside lower right",
+        "outside lower center",
+        "outside lower left",
+        "outside left lower",
+        "outside left center",
+        "outside left upper",
+    ]
+    | tuple[float, float]
+    | int
+    | None
+)
 
 
 def _default_x_func(stat: sinter.TaskStats) -> float:
@@ -55,7 +86,7 @@ class PlotConfig:
         Y-axis scale ('log' or 'linear').
     figsize : tuple[float, float]
         Figure size in inches.
-    legend_loc : str
+    legend_loc : LegendLocation
         Legend location.
     show_fitting_curve : bool
         Whether to show fitting curves.
@@ -71,7 +102,7 @@ class PlotConfig:
     xscale: str = "log"
     yscale: str = "log"
     figsize: tuple[float, float] = (10, 8)
-    legend_loc: str = "best"
+    legend_loc: LegendLocation = "best"
     show_fitting_curve: bool = False
     show_fitting_params: bool = True
     color_by_distance: bool = True

--- a/tests/test_rotated_surface_code.py
+++ b/tests/test_rotated_surface_code.py
@@ -73,6 +73,14 @@ class TestPatchCoordinates:
 class TestBuilderCube:
     """Tests for RotatedSurfaceCodeLayoutBuilder.cube static method."""
 
+    @staticmethod
+    def _translate_coords(coords: PatchCoordinates, offset: Coord2D) -> PatchCoordinates:
+        return PatchCoordinates(
+            data=frozenset(Coord2D(coord.x + offset.x, coord.y + offset.y) for coord in coords.data),
+            ancilla_x=frozenset(Coord2D(coord.x + offset.x, coord.y + offset.y) for coord in coords.ancilla_x),
+            ancilla_z=frozenset(Coord2D(coord.x + offset.x, coord.y + offset.y) for coord in coords.ancilla_z),
+        )
+
     def test_cube_basic(self) -> None:
         """Test basic cube layout generation."""
         boundary = {
@@ -154,6 +162,21 @@ class TestBuilderCube:
 
         assert isinstance(coords, PatchCoordinates)
         assert len(coords.data) > 0
+
+    def test_cube_at_offset_matches_translated_origin_cube(self) -> None:
+        """Test arbitrary physical offsets without slot spacing."""
+        boundary = {
+            BoundarySide.TOP: EdgeSpecValue.X,
+            BoundarySide.BOTTOM: EdgeSpecValue.X,
+            BoundarySide.LEFT: EdgeSpecValue.Z,
+            BoundarySide.RIGHT: EdgeSpecValue.Z,
+        }
+        offset = Coord2D(7, -3)
+
+        origin = Builder.cube(code_distance=3, global_pos=Coord2D(0, 0), boundary=boundary)
+        shifted = Builder.cube_at_offset(code_distance=3, offset=offset, boundary=boundary)
+
+        assert shifted == self._translate_coords(origin, offset)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Restore `RotatedSurfaceCodeLayout.cube_at_offset` for building cube coordinates at an arbitrary physical 2D offset.
- Add the static `RotatedSurfaceCodeLayoutBuilder.cube_at_offset` facade for compatibility with downstream callers.
- Add a regression test that compares `cube_at_offset` with a translated origin cube.

## Context

`graphqomb-paper/experiments/rhg_cut_off` calls `RotatedSurfaceCodeLayoutBuilder.cube_at_offset`, but the current `main` branch only exposes `cube`, which spaces coordinates through `global_pos`. The missing compatibility helper causes RHG graph generation to fail with `AttributeError`.

## Validation

- `env PYTHONPATH=. uv run --no-sync pytest tests/test_rotated_surface_code.py -q`
- `env PYTHONPATH=/home/masa10/git-repos/utftbmqc/ls-pattern-compile:/home/masa10/git-repos/utftbmqc/graphqomb uv run --no-sync pytest graphqomb-paper/experiments/rhg_cut_off/test_rhg_gen.py -q`
- `env PYTHONPATH=. uv run --no-sync pyright`
- `env PYTHONPATH=. uv run --no-sync ruff check lspattern/layout/rotated_surface_code.py tests/test_rotated_surface_code.py`