### PR TITLE
Add PTN export for lspattern canvases

### DIFF
--- a/lspattern/compiler.py
+++ b/lspattern/compiler.py
@@ -165,8 +165,8 @@ def compile_canvas_to_pattern(canvas: Canvas) -> Pattern:
     # extract logical observables from canvas
     logical_observables_nodes: dict[int, set[int]] = {}
     for key, composite_logical_obs in enumerate(canvas.logical_observables):
-        nodes = _collect_logical_observable_nodes(canvas, composite_logical_obs)
-        logical_observables_nodes[key] = {node_map[coord] for coord in nodes}
+        observable_coords = _collect_logical_observable_nodes(canvas, composite_logical_obs)
+        logical_observables_nodes[key] = {node_map[coord] for coord in observable_coords}
 
     return qompile(
         graph,

--- a/lspattern/compiler.py
+++ b/lspattern/compiler.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from graphqomb.common import AxisMeasBasis, Sign
 from graphqomb.graphstate import GraphState
 from graphqomb.noise_model import DepolarizingNoiseModel, MeasurementFlipNoiseModel
+from graphqomb.ptn_format import dump as dump_ptn
 from graphqomb.qompiler import qompile
 from graphqomb.scheduler import Scheduler
 from graphqomb.stim_compiler import stim_compile
@@ -15,6 +16,10 @@ from graphqomb.stim_compiler import stim_compile
 from lspattern.detector import construct_detector
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
+    from graphqomb.pattern import Pattern
+
     from lspattern.canvas import Canvas
     from lspattern.canvas_loader import CompositeLogicalObservableSpec
     from lspattern.mytype import Coord3D
@@ -106,10 +111,37 @@ def compile_canvas_to_stim(
     p_depol_after_clifford: float,
     p_before_meas_flip: float,
 ) -> str:
+    pattern = compile_canvas_to_pattern(canvas)
+    result: str = stim_compile(
+        pattern,
+        emit_qubit_coords=False,
+        noise_models=[
+            DepolarizingNoiseModel(p1=p_depol_after_clifford),
+            MeasurementFlipNoiseModel(p=p_before_meas_flip),
+        ],
+    )
+    return result
+
+
+def compile_canvas_to_pattern(canvas: Canvas) -> Pattern:
+    """Compile a canvas into a GraphQOMB measurement pattern.
+
+    Parameters
+    ----------
+    canvas : Canvas
+        The canvas to compile.
+
+    Returns
+    -------
+    Pattern
+        The compiled GraphQOMB measurement pattern.
+    """
+    nodes = sorted(canvas.nodes)
     graph, node_map = GraphState.from_graph(
-        nodes=canvas.nodes,
-        edges=canvas.edges,
-        meas_bases={node: AxisMeasBasis(canvas.pauli_axes[node], Sign.PLUS) for node in canvas.nodes},
+        nodes=nodes,
+        edges=sorted(canvas.edges),
+        meas_bases={node: AxisMeasBasis(canvas.pauli_axes[node], Sign.PLUS) for node in nodes},
+        coordinates={node: tuple(float(value) for value in node) for node in nodes},
     )
 
     flow = canvas.flow.to_node_flow(node_map)
@@ -125,7 +157,7 @@ def compile_canvas_to_stim(
     # construct detectors
     coord2detectors = construct_detector(canvas.parity_accumulator)
     detectors: list[frozenset[int]] = []
-    for det_coords in coord2detectors.values():
+    for _, det_coords in sorted(coord2detectors.items()):
         det_nodes = {node_map[coord] for coord in det_coords if coord in node_map}
         if det_nodes:
             detectors.append(frozenset(det_nodes))
@@ -136,7 +168,7 @@ def compile_canvas_to_stim(
         nodes = _collect_logical_observable_nodes(canvas, composite_logical_obs)
         logical_observables_nodes[key] = {node_map[coord] for coord in nodes}
 
-    pattern = qompile(
+    return qompile(
         graph,
         flow,
         parity_check_group=detectors,
@@ -144,11 +176,15 @@ def compile_canvas_to_stim(
         scheduler=scheduler,
     )
 
-    result: str = stim_compile(
-        pattern,
-        noise_models=[
-            DepolarizingNoiseModel(p1=p_depol_after_clifford),
-            MeasurementFlipNoiseModel(p=p_before_meas_flip),
-        ],
-    )
-    return result
+
+def export_canvas_to_ptn(canvas: Canvas, output_path: str | Path) -> None:
+    """Export a canvas to GraphQOMB's human-readable .ptn format.
+
+    Parameters
+    ----------
+    canvas : Canvas
+        The canvas to compile and export.
+    output_path : str | Path
+        Path to write the .ptn file.
+    """
+    dump_ptn(compile_canvas_to_pattern(canvas), output_path)

--- a/tests/test_graph_block_yaml.py
+++ b/tests/test_graph_block_yaml.py
@@ -5,10 +5,16 @@ from textwrap import dedent
 
 import pytest
 from graphqomb.graphstate import GraphState
+from graphqomb.ptn_format import load as load_ptn
 from graphqomb.scheduler import Scheduler
 
 from lspattern.canvas_loader import load_canvas
-from lspattern.compiler import _delay_measurements_for_flow, compile_canvas_to_stim
+from lspattern.compiler import (
+    _delay_measurements_for_flow,
+    compile_canvas_to_pattern,
+    compile_canvas_to_stim,
+    export_canvas_to_ptn,
+)
 from lspattern.mytype import Coord2D, Coord3D
 
 
@@ -20,35 +26,7 @@ def _write_json(path: Path, content: str) -> None:
     path.write_text(dedent(content).strip() + "\n", encoding="utf-8")
 
 
-def test_delay_measurements_for_flow_splits_equal_time_dependencies() -> None:
-    graph, node_map = GraphState.from_graph(
-        nodes=["input", "middle", "output"],
-        edges=[("input", "middle"), ("middle", "output")],
-        inputs=["input"],
-        outputs=["output"],
-    )
-    input_node = node_map["input"]
-    middle_node = node_map["middle"]
-    output_node = node_map["output"]
-
-    flow = {input_node: {middle_node}, middle_node: {output_node}}
-    scheduler = Scheduler(graph, flow)
-    scheduler.manual_schedule(
-        prepare_time={middle_node: 0, output_node: 0},
-        measure_time={input_node: 1, middle_node: 1},
-    )
-
-    with pytest.raises(ValueError, match="DAG violation"):
-        scheduler.validate_schedule()
-
-    _delay_measurements_for_flow(scheduler)
-
-    assert scheduler.measure_time[input_node] == 1
-    assert scheduler.measure_time[middle_node] == 2
-    scheduler.validate_schedule()
-
-
-def test_load_canvas_with_graph_block(tmp_path: Path) -> None:
+def _write_graph_canvas_fixture(tmp_path: Path) -> Path:
     graph_json = """
     {
       "coord_mode": "local",
@@ -98,6 +76,39 @@ def test_load_canvas_with_graph_block(tmp_path: Path) -> None:
     _write_yaml(tmp_path / "graph_block.yml", block_yaml)
     canvas_path = tmp_path / "graph_canvas.yml"
     _write_yaml(canvas_path, canvas_yaml)
+    return canvas_path
+
+
+def test_delay_measurements_for_flow_splits_equal_time_dependencies() -> None:
+    graph, node_map = GraphState.from_graph(
+        nodes=["input", "middle", "output"],
+        edges=[("input", "middle"), ("middle", "output")],
+        inputs=["input"],
+        outputs=["output"],
+    )
+    input_node = node_map["input"]
+    middle_node = node_map["middle"]
+    output_node = node_map["output"]
+
+    flow = {input_node: {middle_node}, middle_node: {output_node}}
+    scheduler = Scheduler(graph, flow)
+    scheduler.manual_schedule(
+        prepare_time={middle_node: 0, output_node: 0},
+        measure_time={input_node: 1, middle_node: 1},
+    )
+
+    with pytest.raises(ValueError, match="DAG violation"):
+        scheduler.validate_schedule()
+
+    _delay_measurements_for_flow(scheduler)
+
+    assert scheduler.measure_time[input_node] == 1
+    assert scheduler.measure_time[middle_node] == 2
+    scheduler.validate_schedule()
+
+
+def test_load_canvas_with_graph_block(tmp_path: Path) -> None:
+    canvas_path = _write_graph_canvas_fixture(tmp_path)
 
     canvas, _spec = load_canvas(canvas_path, code_distance=3)
 
@@ -124,3 +135,24 @@ def test_load_canvas_with_graph_block(tmp_path: Path) -> None:
     circuit = compile_canvas_to_stim(canvas, p_depol_after_clifford=0.0, p_before_meas_flip=0.0)
     assert circuit
     assert "OBSERVABLE_INCLUDE" in circuit
+
+
+def test_export_canvas_to_ptn_roundtrips_graphqomb_pattern(tmp_path: Path) -> None:
+    canvas_path = _write_graph_canvas_fixture(tmp_path)
+    canvas, _spec = load_canvas(canvas_path, code_distance=3)
+
+    pattern = compile_canvas_to_pattern(canvas)
+    output_path = tmp_path / "graph_canvas.ptn"
+    export_canvas_to_ptn(canvas, str(output_path))
+
+    ptn_text = output_path.read_text(encoding="utf-8")
+    loaded = load_ptn(output_path)
+
+    assert "# GraphQOMB Pattern Format v1" in ptn_text
+    assert "N 0 8.0 0.0 12.0" in ptn_text
+    assert "N 1 10.0 0.0 12.0" in ptn_text
+    assert loaded.coordinates == pattern.coordinates
+    assert loaded.pauli_frame.xflow == pattern.pauli_frame.xflow
+    assert loaded.pauli_frame.zflow == pattern.pauli_frame.zflow
+    assert loaded.pauli_frame.parity_check_group == pattern.pauli_frame.parity_check_group
+    assert loaded.pauli_frame.logical_observables == pattern.pauli_frame.logical_observables


### PR DESCRIPTION
## Summary

Adds a public lspattern API for exporting compiled canvases to GraphQOMB's human-readable `.ptn` format.

## Changes

- Added `compile_canvas_to_pattern(canvas)` to build a GraphQOMB `Pattern` directly from an lspattern `Canvas`.
- Added `export_canvas_to_ptn(canvas, output_path)` to write that pattern through `graphqomb.ptn_format.dump`.
- Reused the new pattern compilation path from `compile_canvas_to_stim` so Stim and PTN exports share the same lowering logic.
- Added a round-trip test that writes a `.ptn`, loads it back with GraphQOMB, and checks coordinates plus Pauli frame metadata.

## Validation

- `pytest tests/test_graph_block_yaml.py -q`
- `pytest tests/test_design_yaml_integration.py -q` (`10 passed, 1 xfailed` before commit)
- `ruff check lspattern/compiler.py tests/test_graph_block_yaml.py`
- `pyright lspattern/compiler.py tests/test_graph_block_yaml.py`
- `ruff format --check lspattern/compiler.py tests/test_graph_block_yaml.py`